### PR TITLE
Add `with_children: bool` to `delete_all()`, to allow calling delete_all on an `is_root=True` base class, to delete any subclass rows as well.

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -906,6 +906,7 @@ class Document(
         cls,
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
+        with_children: bool = False
         **pymongo_kwargs,
     ) -> Optional[DeleteResult]:
         """
@@ -916,7 +917,7 @@ class Document(
         :param **pymongo_kwargs: pymongo native parameters for delete operation
         :return: Optional[DeleteResult] - pymongo DeleteResult instance.
         """
-        return await cls.find_all().delete(
+        return await cls.find_all(with_children=with_children).delete(
             session=session, bulk_writer=bulk_writer, **pymongo_kwargs
         )
 

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -906,7 +906,7 @@ class Document(
         cls,
         session: Optional[ClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
-        with_children: bool = False
+        with_children: bool = False,
         **pymongo_kwargs,
     ) -> Optional[DeleteResult]:
         """

--- a/docs/tutorial/inheritance.md
+++ b/docs/tutorial/inheritance.md
@@ -127,7 +127,15 @@ await Vehicle.get(bus_2.id, with_children=True)
 # Bus(fuel='diesel', ..., color='yellow', body='minibus', seats=26)
 ```
 
-To delete all Documents in an inheritance tree, `with_children=True` can be passed to `delete_all()`:
+To delete all Documents in an inheritance tree, you can search with `with_children=True` and then delete:
+
+```python
+await Vehicle.find_all(with_children=True).delete()
+# will delete documents matching Vehicle, Car, Bus, etc ..
+# use with care!
+```
+
+Or `with_children=True` can be passed directly to `delete_all()`:
 
 ```python
 await Vehicle.delete_all(with_children=True)

--- a/docs/tutorial/inheritance.md
+++ b/docs/tutorial/inheritance.md
@@ -130,7 +130,7 @@ await Vehicle.get(bus_2.id, with_children=True)
 To delete all Documents in an inheritance tree, `with_children=True` can be passed to `delete_all()`:
 
 ```python
-await Vehicle.delete_all(with_children=true)
+await Vehicle.delete_all(with_children=True)
 # will delete documents matching Vehicle, Car, Bus, etc ..
 # use with care!
 ```

--- a/docs/tutorial/inheritance.md
+++ b/docs/tutorial/inheritance.md
@@ -127,6 +127,14 @@ await Vehicle.get(bus_2.id, with_children=True)
 # Bus(fuel='diesel', ..., color='yellow', body='minibus', seats=26)
 ```
 
+To delete all Documents in an inheritance tree, `with_children=True` can be passed to `delete_all()`:
+
+```python
+Vehicle.delete_all(with_children=true)
+# will delete documents matching Vehicle, Car, Bus, etc ..
+# use with care!
+```
+
 ### Relations
 
 Linked documents will be resolved into the respective classes

--- a/docs/tutorial/inheritance.md
+++ b/docs/tutorial/inheritance.md
@@ -130,7 +130,7 @@ await Vehicle.get(bus_2.id, with_children=True)
 To delete all Documents in an inheritance tree, `with_children=True` can be passed to `delete_all()`:
 
 ```python
-Vehicle.delete_all(with_children=true)
+await Vehicle.delete_all(with_children=true)
 # will delete documents matching Vehicle, Car, Bus, etc ..
 # use with care!
 ```


### PR DESCRIPTION
A simple change: adds `with_children: bool` to `delete_all()`, which gets passed through to `find_all()`.

When there is an inheritance tree, this allows deleting all documents in a collection using the base class in one simple operation.