### PR TITLE
Add missing type signature to `BaseFindComparisonOperator` constructor

### DIFF
--- a/beanie/odm/operators/find/comparison.py
+++ b/beanie/odm/operators/find/comparison.py
@@ -8,7 +8,7 @@ class BaseFindComparisonOperator(BaseFindOperator):
         self,
         field,
         other,
-    ):
+    ) -> None:
         self.field = field
         self.other = other
 


### PR DESCRIPTION
Fix #836 , #672 