### PR TITLE
Fix: Set default value in FindInterface._inheritance_inited to avoid …

### DIFF
--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -39,7 +39,7 @@ class FindInterface:
     _find_one_query_class: ClassVar[Type] = FindOne
     _find_many_query_class: ClassVar[Type] = FindMany
 
-    _inheritance_inited: bool
+    _inheritance_inited: bool = False
     _class_id: ClassVar[Optional[str]]
     _children: ClassVar[Dict[str, Type]]
 


### PR DESCRIPTION
…AttributeError in _add_class_id_filter method

Fixed error raised when in "FindInterface._add_class_id_filter" method (line 458) when a attempt to acess the value from "FindInterface._inheritance_inited"