### PR TITLE
[Feature] Adding documents with session

### DIFF
--- a/beanie/odm/interfaces/session.py
+++ b/beanie/odm/interfaces/session.py
@@ -1,6 +1,8 @@
-from typing import Optional
+from contextvars import ContextVar
+from typing import Optional, ClassVar
 
 from pymongo.client_session import ClientSession
+import motor.motor_asyncio
 
 
 class SessionMethods:
@@ -17,3 +19,39 @@ class SessionMethods:
         if session is not None:
             self.session: Optional[ClientSession] = session
         return self
+
+
+class DocumentSessionMethods:
+    """
+    Document session methods
+    """
+
+    __session__: ClassVar[ContextVar[Optional[motor.motor_asyncio.AsyncIOMotorClientSession]]] = ContextVar(
+        "session", default=None
+    )
+
+    @classmethod
+    def set_session(cls, session: Optional[motor.motor_asyncio.AsyncIOMotorClientSession] = None):
+        """
+        Set session to the ClassVar context
+        :param session: Optional[ClientSession] - pymongo session
+        :return:
+        """
+        if session is not None:
+            cls.__session__.set(session)
+
+    @classmethod
+    def get_session(cls) -> Optional[motor.motor_asyncio.AsyncIOMotorClientSession]:
+        """
+        Get session from the ClassVar context
+        :return: Optional[ClientSession]
+        """
+        return cls.__session__.get()
+
+    @classmethod
+    def clear_session(cls):
+        """
+        Clear session from the ClassVar context
+        :return:
+        """
+        cls.__session__.set(None)

--- a/beanie/odm/interfaces/session.py
+++ b/beanie/odm/interfaces/session.py
@@ -26,12 +26,17 @@ class DocumentSessionMethods:
     Document session methods
     """
 
-    __session__: ClassVar[ContextVar[Optional[motor.motor_asyncio.AsyncIOMotorClientSession]]] = ContextVar(
-        "session", default=None
-    )
+    __session__: ClassVar[
+        ContextVar[Optional[motor.motor_asyncio.AsyncIOMotorClientSession]]
+    ] = ContextVar("session", default=None)
 
     @classmethod
-    def set_session(cls, session: Optional[motor.motor_asyncio.AsyncIOMotorClientSession] = None):
+    def set_session(
+        cls,
+        session: Optional[
+            motor.motor_asyncio.AsyncIOMotorClientSession
+        ] = None,
+    ):
         """
         Set session to the ClassVar context
         :param session: Optional[ClientSession] - pymongo session
@@ -41,7 +46,9 @@ class DocumentSessionMethods:
             cls.__session__.set(session)
 
     @classmethod
-    def get_session(cls) -> Optional[motor.motor_asyncio.AsyncIOMotorClientSession]:
+    def get_session(
+        cls,
+    ) -> Optional[motor.motor_asyncio.AsyncIOMotorClientSession]:
         """
         Get session from the ClassVar context
         :return: Optional[ClientSession]

--- a/docs/tutorial/sessions.md
+++ b/docs/tutorial/sessions.md
@@ -1,0 +1,122 @@
+# Session Handling
+
+When sessions are required to enable transactional rollbacks, atomically the write methods inherited from the `Document` 
+class can be used. We can pass a `session` argument to the write methods to enable session handling.
+
+## Sessions In Document Read/Write Methods
+
+Let's define a document and initialize it to be used:
+
+```python
+from beanie import Document, init_beanie
+import motor.motor_asyncio
+
+class Bike(Document):
+    number_of_wheels: int
+    color: str
+    brand: str
+
+
+async def main():
+    uri = "mongodb://beanie:beanie@localhost:27017"
+    client = motor.motor_asyncio.AsyncIOMotorClient(uri)
+    db = client.bikes
+
+    await init_beanie(
+        database=db, 
+        document_models=[Bike],
+    )
+
+    async with await client.start_session() as session:
+        async with session.start_transaction():
+            bike = Bike(
+                number_of_wheels=2,
+                color="red",
+                brand="Yamaha"
+            )
+            await bike.insert_one(session=session)
+        
+            bike_from_db = await Bike.get(bike.id, session=session)
+            print(bike_from_db)
+```
+
+The above will print out to:
+
+```
+>>> Bike(number_of_wheels=2, color="red", brand="BMX")
+```
+
+All is good and the session is working as expected. But notice that we have to pass a `session` argument to each of the 
+write methods. This can be cumbersome and error-prone. To avoid this, we can initialize the document with a session.
+
+## Documents With Session
+
+In many use cases, when we need to make sure database transactions are rolled back atomically triggered by an exception 
+or any other conditions, database sessions are required to make this happen. To avoid passing the `session` argument to 
+every read/write methods of the document, we can initialize the document with a session.
+
+Let's take the first example and modify it to initialize the document with a session:
+
+```python
+from contextlib import asynccontextmanager
+from typing import List
+
+from beanie import Document, init_beanie
+import motor.motor_asyncio
+
+
+class Bike(Document):
+    number_of_wheels: int
+    color: str
+    brand: str
+
+
+@asynccontextmanager
+async def with_session(*, client: motor.motor_asyncio.AsyncIOMotorClient, collections: List[Document] | None = None):
+    async with await client.start_session() as session:
+        async with session.start_transaction():
+            try:
+                if collections and isinstance(collections, list) and len(collections) > 0:
+                    for collection in collections:
+                        collection.set_session(session)
+                yield session
+            except Exception:
+                await session.abort_transaction()
+            else:
+                await session.commit_transaction()
+            finally:
+                if collections and isinstance(collections, list) and len(collections) > 0:
+                    for collection in collections:
+                        collection.clear_session()    
+
+
+async def main():
+    uri = "mongodb://beanie:beanie@localhost:27017"
+    client = motor.motor_asyncio.AsyncIOMotorClient(uri)
+    db = client.bikes
+
+    await init_beanie(
+        database=db, 
+        document_models=[Bike],
+    )
+
+    async with await with_session(client=client, collections=[Bike]) as session:
+        bike = Bike(
+            number_of_wheels=2,
+            color="red",
+            brand="Yamaha"
+        )
+        await bike.insert_one(session=session)
+        raise Exception("Something went wrong, rollback please")
+    
+    bike_from_db = await Bike.get(bike.id, session=session)
+    print(bike_from_db)
+```
+
+In this case, stdout will print out:
+
+```
+>>> None
+```
+
+With the example above, we can be certain that the transaction will be rolled back if an exception is raised.

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -99,6 +99,8 @@ renderer:
           source: docs/tutorial/on_save_validation.md
         - title: Migrations
           source: docs/tutorial/migrations.md
+        - title: Sessions
+          source: docs/tutorial/sessions.md
     - title: Batteries
       children:
         - title: Queue

--- a/tests/odm/test_document_session.py
+++ b/tests/odm/test_document_session.py
@@ -1,0 +1,60 @@
+from contextlib import asynccontextmanager
+from typing import List
+
+import motor.motor_asyncio
+
+from beanie import Document, init_beanie
+from tests.odm.models import DocumentTestModelWithCustomCollectionName, SubDocument
+
+
+@asynccontextmanager
+async def with_session(*, client: motor.motor_asyncio.AsyncIOMotorClient, collections: List[Document] | None = None):
+    async with await client.start_session() as session:
+        async with session.start_transaction():
+            try:
+                if collections and isinstance(collections, list) and len(collections) > 0:
+                    for collection in collections:
+                        collection.set_session(session)
+                yield session
+            except Exception:
+                await session.abort_transaction()
+            else:
+                await session.commit_transaction()
+            finally:
+                if collections and isinstance(collections, list) and len(collections) > 0:
+                    for collection in collections:
+                        collection.clear_session()
+
+
+class DocumentWithSession(Document):
+    prop1: int
+    prop2: str
+
+
+class TestDocumentSession:
+    async def test_document_session_in_place_rollback(self, cli: motor.motor_asyncio.AsyncIOMotorClient):
+        async with with_session(client=cli) as _session:
+            subdoc = SubDocument(test_str="test_subdoc", test_int=528)
+            doc = DocumentTestModelWithCustomCollectionName(test_int=7, test_list=[subdoc], test_str="test")
+            await doc.save(session=_session)
+
+            assert doc.id is not None
+            raise Exception("Rollback")
+
+        doc = await DocumentTestModelWithCustomCollectionName.get(doc.id)
+
+        assert doc is None
+
+    async def test_document_session_with_custom_doc_rollback(self, cli: motor.motor_asyncio.AsyncIOMotorClient):
+        await init_beanie(cli["beanie_db"], document_models=[DocumentWithSession])
+
+        async with with_session(client=cli, collections=[DocumentWithSession]) as _session:
+            doc = DocumentWithSession(prop1=7, prop2="test")
+            await doc.save()
+
+            assert doc.id is not None
+            raise Exception("Rollback")
+
+        doc = await DocumentWithSession.get(doc.id)
+
+        assert doc is None


### PR DESCRIPTION
Instead of passing the `session` objects in document read/write methods, use a `ContextVar` to hold a session for documents. This makes it a lot simpler if this is built in with the `Document` object. This PR tries to do that.

Also added a page in the docs site to describe how to use it.