### PR TITLE
Fix typo in source code comment in inheritance.md

### DIFF
--- a/docs/tutorial/inheritance.md
+++ b/docs/tutorial/inheritance.md
@@ -88,7 +88,7 @@ owner = await Owner(name='John', vehicles=[car_1, car_2, bus_1]).insert()
 With parameter `with_children = True` the find query results will contain all the children classes' objects.
 
 ```python
-# this query returns vehicles of all types that have white color, becuase `with_children` is True
+# this query returns vehicles of all types that have white color, because `with_children` is True
 white_vehicles = await Vehicle.find(Vehicle.color == 'white', with_children=True).to_list()
 # [
 #    Bicycle(..., color='white', frame=54, wheels=29),


### PR DESCRIPTION
Typo can be seen online at https://beanie-odm.dev/tutorial/inheritance/:

![image](https://github.com/user-attachments/assets/ad3f43d8-d247-4aa8-a990-328898ac14e9)

----

*The work on this PR was sponsored by [SUSI&James GmbH](https://susiandjames.com/).*