### PR TITLE
Extend motor option to beanie

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ pip install beanie
 ```shell
 poetry add beanie
 ```
+
+For more installation options (eg: `aws`, `gcp`, `srv` ...) you can look in the [getting started](./docs/getting-started.md#optional-dependencies)
+
 ## Example
 
 ```python

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,62 @@ pip install beanie
 poetry add beanie
 ```
 
+### Optional dependencies
+
+Beanie supports some optional dependencies from Motor (`pip` or `poetry` can be used).
+
+GSSAPI authentication requires `gssapi` extra dependency:
+
+```bash
+pip install "beanie[gssapi]"
+```
+
+MONGODB-AWS authentication requires `aws` extra dependency:
+
+```bash
+pip install "beanie[aws]"
+```
+
+Support for mongodb+srv:// URIs requires `srv` extra dependency:
+
+```bash
+pip install "beanie[srv]"
+```
+
+OCSP requires `ocsp` extra dependency:
+
+```bash
+pip install "beanie[ocsp]"
+```
+
+Wire protocol compression with snappy requires `snappy` extra
+dependency:
+
+```bash
+pip install "beanie[snappy]"
+```
+
+Wire protocol compression with zstandard requires `zstd` extra
+dependency:
+
+```bash
+pip install "beanie[zstd]"
+```
+
+Client-Side Field Level Encryption requires `encryption` extra
+dependency:
+
+```bash
+pip install "beanie[encryption]"
+```
+
+You can install all dependencies automatically with the following
+command:
+
+```bash
+pip install "beanie[gssapi,aws,ocsp,snappy,srv,zstd,encryption]"
+```
+
 ## Initialization
 
 Getting Beanie setup in your code is really easy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ ci = [
     "requests",
     "types-requests",
 ]
+aws = ["motor[aws]>=2.5.0,<4.0.0"]
+encryption = ["motor[encryption]>=2.5.0,<4.0.0"]
+gssapi = ["motor[gssapi]>=2.5.0,<4.0.0"]
+ocsp = ["motor[ocsp]>=2.5.0,<4.0.0"]
+snappy = ["motor[snappy]>=2.5.0,<4.0.0"]
+zstd = ["motor[zstd]>=2.5.0,<4.0.0"]
 
 [project.urls]
 homepage = "https://beanie-odm.dev"


### PR DESCRIPTION
Add the possibility to install optional packages from motor.
As an example using the the aws option allow to connect with an IAM role.