### PR TITLE
Add test to ensure dict with enum keys are encoded properly

### DIFF
--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -44,6 +44,7 @@ from tests.odm.models import (
     DocumentWithCustomInit,
     DocumentWithDecimalField,
     DocumentWithDeprecatedHiddenField,
+    DocumentWithEnumKeysDict,
     DocumentWithExtras,
     DocumentWithHttpUrlField,
     DocumentWithIndexedObjectId,
@@ -290,6 +291,7 @@ async def init(db):
         DocumentToTestSync,
         DocumentWithLinkForNesting,
         DocumentWithBackLinkForNesting,
+        DocumentWithEnumKeysDict,
         LongSelfLink,
     ]
     await init_beanie(

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -1134,3 +1134,12 @@ class LongSelfLink(Document):
 
     class Settings:
         max_nesting_depth = 50
+
+
+class DictEnum(str, Enum):
+    RED = "Red"
+    BLUE = "Blue"
+
+
+class DocumentWithEnumKeysDict(Document):
+    color: Dict[DictEnum, str]

--- a/tests/odm/test_encoder.py
+++ b/tests/odm/test_encoder.py
@@ -1,5 +1,6 @@
 import re
 from datetime import date, datetime
+from enum import Enum
 from uuid import uuid4
 
 import pytest
@@ -10,10 +11,12 @@ from beanie.odm.utils.encoder import Encoder
 from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
 from tests.odm.models import (
     Child,
+    DictEnum,
     DocumentForEncodingTest,
     DocumentForEncodingTestDate,
     DocumentWithComplexDictKey,
     DocumentWithDecimalField,
+    DocumentWithEnumKeysDict,
     DocumentWithHttpUrlField,
     DocumentWithKeepNullsFalse,
     DocumentWithStringField,
@@ -169,3 +172,14 @@ async def test_dict_with_complex_key():
 
     assert isinstance(new_doc.dict_field, dict)
     assert new_doc.dict_field.get(uuid) == dt
+
+
+async def test_dict_with_enum_keys():
+    doc = DocumentWithEnumKeysDict(color={DictEnum.RED: "favorite"})
+    await doc.save()
+
+    assert isinstance(doc.color, dict)
+
+    for key in doc.color:
+        assert isinstance(key, Enum)
+        assert key == DictEnum.RED


### PR DESCRIPTION
The issue raised in #829 seems to have been fixed in PR #868 

https://github.com/BeanieODM/beanie/blob/0b8d50ba1fff44d7b92d726a1376619cacb4c5fd/beanie/odm/utils/encoder.py#L134-L138

Only the relevant test was missing to ensure the regression was adequately addressed. This PR adds that test.