### PR TITLE
Use session in document insert

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -346,7 +346,9 @@ class Document(
                         LinkTypes.OPTIONAL_DIRECT,
                     ]:
                         if isinstance(value, Document):
-                            await value.save(link_rule=WriteRules.WRITE)
+                            await value.save(
+                                link_rule=WriteRules.WRITE, session=session
+                            )
                     if field_info.link_type in [
                         LinkTypes.LIST,
                         LinkTypes.OPTIONAL_LIST,
@@ -354,7 +356,10 @@ class Document(
                         if isinstance(value, List):
                             await asyncio.gather(
                                 *[
-                                    obj.save(link_rule=WriteRules.WRITE)
+                                    obj.save(
+                                        link_rule=WriteRules.WRITE,
+                                        session=session,
+                                    )
                                     for obj in value
                                     if isinstance(obj, Document)
                                 ]


### PR DESCRIPTION
# Summary
This PR fixes a transactional integrity issue in Beanie by ensuring that document saves are correctly associated with the current transaction session.

## Problem
When saving documents within a transaction using Beanie, a bug causes linked documents to be saved outside the transaction context if the session parameter is not explicitly provided. This behavior can lead to partial updates where some documents are persisted even if the transaction fails, undermining the purpose of using transactions.

## Solution
The change explicitly adds `session=session` to the `save` function for documents within a transaction. This ensures that all document saves are bound to the active transaction, preventing unintended persistence of documents if the transaction is rolled back.


This fix maintains the atomicity of transactions by ensuring all operations are executed within the transaction context, thus preserving data consistency and integrity.
