### PR TITLE
Fix bug #1008 in the json_schema export of document with BackLink

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -487,7 +487,17 @@ class BackLink(Generic[T]):
         def __get_pydantic_core_schema__(
             cls, source_type: Any, handler: GetCoreSchemaHandler
         ) -> CoreSchema:  # type: ignore
-            return plain_validator(cls.build_validation(handler, source_type))
+            # build_validation can return any object
+            # so json_schema should be a general dict 
+            return core_schema.json_or_python_schema(
+                python_schema = plain_validator(
+                    cls.build_validation(handler, source_type),
+                ),
+                json_schema = core_schema.dict_schema(
+                    keys_schema=core_schema.str_schema(), 
+                    values_schema=core_schema.any_schema()
+                ),
+            )
 
     else:
 

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -488,14 +488,14 @@ class BackLink(Generic[T]):
             cls, source_type: Any, handler: GetCoreSchemaHandler
         ) -> CoreSchema:  # type: ignore
             # build_validation can return any object
-            # so json_schema should be a general dict 
+            # so json_schema should be a general dict
             return core_schema.json_or_python_schema(
-                python_schema = plain_validator(
+                python_schema=plain_validator(
                     cls.build_validation(handler, source_type),
                 ),
-                json_schema = core_schema.dict_schema(
-                    keys_schema=core_schema.str_schema(), 
-                    values_schema=core_schema.any_schema()
+                json_schema=core_schema.dict_schema(
+                    keys_schema=core_schema.str_schema(),
+                    values_schema=core_schema.any_schema(),
                 ),
             )
 

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -843,11 +843,12 @@ class TestSaveBackLinks:
         if IS_PYDANTIC_V2:
             json_schema = DocumentWithListBackLink.model_json_schema()
         else:
-            import json
+            return  # schema does not work in pydantic v1 due to pydantic bug #3390
+            json_schema = DocumentWithListBackLink.schema()
 
-            json_schema = json.loads(DocumentWithListBackLink.schema_json())
         assert (
-            json_schema["properties"]["back_link"]["items"]["type"] == "object"
+            json_schema["properties"]["back_link"]["items"]
+            and json_schema["properties"]["back_link"]["type"] == "array"
         )
 
 

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -840,8 +840,16 @@ class TestSaveBackLinks:
             assert lnk.s == "new value"
 
     def test_json_schema_export(self):
-        json_schema = DocumentWithListBackLink.model_json_schema()
-        assert json_schema['properties']['back_link']['items']['type'] == 'object'
+        if IS_PYDANTIC_V2:
+            json_schema = DocumentWithListBackLink.model_json_schema()
+        else:
+            import json
+
+            json_schema = json.loads(DocumentWithListBackLink.schema_json())
+        assert (
+            json_schema["properties"]["back_link"]["items"]["type"] == "object"
+        )
+
 
 class HouseForReversedOrderInit(Document):
     name: str

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -839,6 +839,9 @@ class TestSaveBackLinks:
         for lnk in new_back_link_doc.back_link:
             assert lnk.s == "new value"
 
+    def test_json_schema_export(self):
+        json_schema = DocumentWithListBackLink.model_json_schema()
+        assert json_schema['properties']['back_link']['items']['type'] == 'object'
 
 class HouseForReversedOrderInit(Document):
     name: str


### PR DESCRIPTION
This PR fixes bug #1008 and adds test for the model_json_schema() method of a document with a BackLink.