### PR TITLE
Set max pymongo version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "pydantic>=1.10,<3.0",
     "motor>=2.5.0,<4.0.0",
+    "pymongo<4.9",
     "click>=7",
     "toml",
     "lazy-model==0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=1.10,<3.0",
-    "motor>=2.5.0,<4.0.0",
-    "pymongo<4.9",
+    "motor~=3.6.0",
+    "pymongo~=4.9.1",
     "click>=7",
     "toml",
     "lazy-model==0.2.0",


### PR DESCRIPTION
Temporary solution:

A new version of pymongo has been released. Beanie doesn't support it yet. When installing motor, the new version 4.9 will be picked up. There will be an ImportError when running the application:

```
Traceback (most recent call last):
  File "/usr/app/src/main.py", line 1, in <module>
    from beanie import init_beanie
  File "/usr/local/lib/python3.12/site-packages/beanie/__init__.py", line 1, in <module>
    from beanie.migrations.controllers.free_fall import free_fall_migration
  File "/usr/local/lib/python3.12/site-packages/beanie/migrations/controllers/free_fall.py", line 4, in <module>
    from beanie.migrations.controllers.base import BaseMigrationController
  File "/usr/local/lib/python3.12/site-packages/beanie/migrations/controllers/base.py", line 4, in <module>
    from beanie.odm.documents import Document
  File "/usr/local/lib/python3.12/site-packages/beanie/odm/documents.py", line 69, in <module>
    from beanie.odm.interfaces.aggregate import AggregateInterface
  File "/usr/local/lib/python3.12/site-packages/beanie/odm/interfaces/aggregate.py", line 7, in <module>
    from beanie.odm.queries.aggregation import AggregationQuery
  File "/usr/local/lib/python3.12/site-packages/beanie/odm/queries/aggregation.py", line 12, in <module>
    from motor.core import AgnosticCommandCursor
  File "/usr/local/lib/python3.12/site-packages/motor/core.py", line 30, in <module>
    from pymongo.cursor import _QUERY_OPTIONS, Cursor, RawBatchCursor
ImportError: cannot import name '_QUERY_OPTIONS' from 'pymongo.cursor' (/usr/local/lib/python3.12/site-packages/pymongo/cursor.py)
```

What I did:
Wrote **pymongo<4.9** as a library dependency in pyproject.toml