### PR TITLE
Add DocumentDB compatibility to fetch_links

### DIFF
--- a/beanie/odm/utils/find.py
+++ b/beanie/odm/utils/find.py
@@ -66,7 +66,7 @@ def construct_query(
                     }
                 },
                 {
-                    "$set": {
+                    "$addFields": {
                         link_info.field_name: {
                             "$cond": {
                                 "if": {
@@ -81,7 +81,7 @@ def construct_query(
                         }
                     }
                 },
-                {"$unset": f"_link_{link_info.field_name}"},
+                {"$project": {f"_link_{link_info.field_name}": 0}},
             ]  # type: ignore
             new_depth = (
                 current_depth - 1 if current_depth is not None else None
@@ -122,7 +122,7 @@ def construct_query(
                     }
                 },
                 {
-                    "$set": {
+                    "$addFields": {
                         link_info.field_name: {
                             "$cond": {
                                 "if": {
@@ -137,7 +137,7 @@ def construct_query(
                         }
                     }
                 },
-                {"$unset": f"_link_{link_info.field_name}"},
+                {"$project": {f"_link_{link_info.field_name}": 0}},
             ]
             new_depth = (
                 current_depth - 1 if current_depth is not None else None
@@ -172,7 +172,7 @@ def construct_query(
                     }
                 },
                 {
-                    "$set": {
+                    "$addFields": {
                         link_info.field_name: {
                             "$cond": {
                                 "if": {
@@ -187,7 +187,7 @@ def construct_query(
                         }
                     }
                 },
-                {"$unset": f"_link_{link_info.field_name}"},
+                {"$project": {f"_link_{link_info.field_name}": 0}},
             ]  # type: ignore
             new_depth = (
                 current_depth - 1 if current_depth is not None else None
@@ -231,7 +231,7 @@ def construct_query(
                     }
                 },
                 {
-                    "$set": {
+                    "$addFields": {
                         link_info.field_name: {
                             "$cond": {
                                 "if": {
@@ -246,7 +246,7 @@ def construct_query(
                         }
                     }
                 },
-                {"$unset": f"_link_{link_info.field_name}"},
+                {"$project": {f"_link_{link_info.field_name}": 0}},
             ]
             new_depth = (
                 current_depth - 1 if current_depth is not None else None


### PR DESCRIPTION
DocumentDB does not support `$set` and `$unset` in aggregation pipelines. This PR will change the pipelines for `fetch_links=True` to not use them.

The `$set` operator is synonymous with `$addFields` (no idea why), and `$unset` is an alias for `$project` setting the values to `0`. As such this is no more/less efficient, it's just an improvement in compatibility.

This is retarget of https://github.com/BeanieODM/bunnet/pull/19 which was closed due to inactivity, but I figure patching here will eventually get merged back over into Bunnet regardless.

FWIW this does not necessarily fix all compatibility; just this specific aspect.