### PR TITLE
Add AggregationMethod to Document and UnionDoc

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -66,6 +66,7 @@ from beanie.odm.fields import (
     WriteRules,
 )
 from beanie.odm.interfaces.aggregate import AggregateInterface
+from beanie.odm.interfaces.aggregation_methods import AggregateMethods
 from beanie.odm.interfaces.detector import ModelType
 from beanie.odm.interfaces.find import FindInterface
 from beanie.odm.interfaces.getters import OtherGettersInterface
@@ -158,6 +159,7 @@ class Document(
     InheritanceInterface,
     FindInterface,
     AggregateInterface,
+    AggregateMethods,
     OtherGettersInterface,
 ):
     """

--- a/beanie/odm/interfaces/aggregation_methods.py
+++ b/beanie/odm/interfaces/aggregation_methods.py
@@ -16,18 +16,16 @@ class AggregateMethods:
     """
 
     @abstractmethod
-    @classmethod
     def aggregate(
-        cls: Type[DocType],
+        self,
         aggregation_pipeline,
         projection_model=None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
     ): ...
 
-    @classmethod
     async def sum(
-        cls: Type[DocType],
+        self,
         field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
@@ -60,7 +58,7 @@ class AggregateMethods:
         # As we did not supply a projection we can safely cast the type (hinting to mypy that we know the type)
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await cls.aggregate(
+            await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,
@@ -70,9 +68,8 @@ class AggregateMethods:
             return None
         return result[0]["sum"]
 
-    @classmethod
     async def avg(
-        cls: Type[DocType],
+        self,
         field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
@@ -103,7 +100,7 @@ class AggregateMethods:
 
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await cls.aggregate(
+            await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,
@@ -113,9 +110,8 @@ class AggregateMethods:
             return None
         return result[0]["avg"]
 
-    @classmethod
     async def max(
-        cls: Type[DocType],
+        self,
         field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
@@ -145,7 +141,7 @@ class AggregateMethods:
 
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await cls.aggregate(
+            await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,
@@ -155,9 +151,8 @@ class AggregateMethods:
             return None
         return result[0]["max"]
 
-    @classmethod
     async def min(
-        cls: Type[DocType],
+        self,
         field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
@@ -187,7 +182,7 @@ class AggregateMethods:
 
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await cls.aggregate(
+            await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,

--- a/beanie/odm/interfaces/aggregation_methods.py
+++ b/beanie/odm/interfaces/aggregation_methods.py
@@ -1,9 +1,13 @@
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
+from pydantic import BaseModel
 
 from beanie.odm.fields import ExpressionField
+
+DocType = TypeVar("DocType", bound="AggregateMethods")
+DocumentProjectionType = TypeVar("DocumentProjectionType", bound=BaseModel)
 
 
 class AggregateMethods:
@@ -20,8 +24,9 @@ class AggregateMethods:
         ignore_cache: bool = False,
     ): ...
 
+    @classmethod
     async def sum(
-        self,
+        cls: Type[DocType],
         field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
@@ -54,7 +59,7 @@ class AggregateMethods:
         # As we did not supply a projection we can safely cast the type (hinting to mypy that we know the type)
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await self.aggregate(
+            await cls.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,
@@ -64,9 +69,10 @@ class AggregateMethods:
             return None
         return result[0]["sum"]
 
+    @classmethod
     async def avg(
-        self,
-        field,
+        cls: Type[DocType],
+        field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
     ) -> Optional[float]:
@@ -96,7 +102,7 @@ class AggregateMethods:
 
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await self.aggregate(
+            await cls.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,
@@ -106,8 +112,9 @@ class AggregateMethods:
             return None
         return result[0]["avg"]
 
+    @classmethod
     async def max(
-        self,
+        cls: Type[DocType],
         field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
@@ -137,7 +144,7 @@ class AggregateMethods:
 
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await self.aggregate(
+            await cls.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,
@@ -147,8 +154,9 @@ class AggregateMethods:
             return None
         return result[0]["max"]
 
+    @classmethod
     async def min(
-        self,
+        cls: Type[DocType],
         field: Union[str, ExpressionField],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
@@ -178,7 +186,7 @@ class AggregateMethods:
 
         result: List[Dict[str, Any]] = cast(
             List[Dict[str, Any]],
-            await self.aggregate(
+            await cls.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
                 ignore_cache=ignore_cache,

--- a/beanie/odm/interfaces/aggregation_methods.py
+++ b/beanie/odm/interfaces/aggregation_methods.py
@@ -16,8 +16,9 @@ class AggregateMethods:
     """
 
     @abstractmethod
+    @classmethod
     def aggregate(
-        self,
+        cls: Type[DocType],
         aggregation_pipeline,
         projection_model=None,
         session: Optional[AsyncIOMotorClientSession] = None,

--- a/beanie/odm/interfaces/aggregation_methods.py
+++ b/beanie/odm/interfaces/aggregation_methods.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, TypeVar, Union, cast
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from pydantic import BaseModel

--- a/beanie/odm/union_doc.py
+++ b/beanie/odm/union_doc.py
@@ -2,6 +2,7 @@ from typing import ClassVar, Dict, Optional, Type, TypeVar
 
 from beanie.exceptions import UnionDocNotInited
 from beanie.odm.interfaces.aggregate import AggregateInterface
+from beanie.odm.interfaces.aggregation_methods import AggregateMethods
 from beanie.odm.interfaces.detector import DetectionInterface, ModelType
 from beanie.odm.interfaces.find import FindInterface
 from beanie.odm.interfaces.getters import OtherGettersInterface
@@ -13,6 +14,7 @@ UnionDocType = TypeVar("UnionDocType", bound="UnionDoc")
 class UnionDoc(
     FindInterface,
     AggregateInterface,
+    AggregateMethods,
     OtherGettersInterface,
     DetectionInterface,
 ):


### PR DESCRIPTION
This PR is to allow the use of aggregation method directly after Document or UnionDoc class like the document mention in 
https://beanie-odm.dev/tutorial/aggregation/

```py
# With a search:
avg_price = await Product.find(
    Product.category.name == "Chocolate"
).avg(Product.price)

# Over the whole collection:
avg_price = await Product.avg(Product.price)
```

which isnt possible since Product doesnt inherit from AggregationMethod