### PR TITLE
Fix `PydanticObjectId` fields being parsed into `str` when using Pydantic's `model_validate_json`

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -159,7 +159,7 @@ class PydanticObjectId(ObjectId):
         ) -> CoreSchema:  # type: ignore
             return core_schema.json_or_python_schema(
                 python_schema=plain_validator(cls.validate),
-                json_schema=str_schema(),
+                json_schema=plain_validator(cls.validate),
                 serialization=core_schema.plain_serializer_function_ser_schema(
                     lambda instance: str(instance), when_used="json"
                 ),

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -58,7 +58,6 @@ if IS_PYDANTIC_V2:
     from pydantic_core.core_schema import (
         ValidationInfo,
         simple_ser_schema,
-        str_schema,
     )
 else:
     from pydantic.fields import ModelField  # type: ignore


### PR DESCRIPTION
Unsure if this could be fixed in a more stylish fashion, but it was simply incorrectly setup before, at least now it works. 

**Please make as many changes as needed if this solution could be improved.**

I believe this bugfix is quite important. If you parse an ID (let's call the variable `identifier`) from a JSON file in order to look it up on your Mongo database... you won't find it.

```python
 await cls.find_one(cls.id == identifier)
```
will return `None` even if the object exists, because `identifier` will be of type `str` instead of `ObjectId` when parsing from a JSON file with Pydantic's `model_validate_json`. 

Fixes #940.