### PR TITLE
start using any io for structured concurency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For more installation options (eg: `aws`, `gcp`, `srv` ...) you can look in the 
 ## Example
 
 ```python
-import asyncio
+import anyio
 from typing import Optional
 
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -94,7 +94,7 @@ async def example():
 
 
 if __name__ == "__main__":
-    asyncio.run(example())
+    anyio.run(example)
 ```
 
 ## Links

--- a/beanie/executors/migrate.py
+++ b/beanie/executors/migrate.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import os
 import shutil
@@ -6,6 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import anyio
 import click
 import toml
 
@@ -197,7 +197,7 @@ def migrate(
     settings_kwargs["use_transaction"] = use_transaction
     settings = MigrationSettings(**settings_kwargs)
 
-    asyncio.run(run_migrate(settings))
+    anyio.run(run_migrate, settings)
 
 
 @migrations.command()

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
@@ -18,6 +17,7 @@ from typing import (
 )
 from typing import OrderedDict as OrderedDictType
 
+from anyio import create_task_group
 from bson import DBRef, ObjectId
 from bson.errors import InvalidId
 from pydantic import BaseModel
@@ -363,10 +363,10 @@ class Link(Generic[T]):
 
     @classmethod
     async def fetch_many(cls, links: List[Link]):
-        coros = []
-        for link in links:
-            coros.append(link.fetch())
-        return await asyncio.gather(*coros)
+        if links:
+            async with create_task_group() as tg:
+                for link in links:
+                    tg.start_soon(link.fetch)
 
     if IS_PYDANTIC_V2:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "toml",
     "lazy-model==0.2.0",
     "typing-extensions>=4.7",
+    "anyio>=4.5.1" #todo when droping python 3.8 update to newest
 ]
 
 [project.optional-dependencies]

--- a/tests/odm/test_concurrency.py
+++ b/tests/odm/test_concurrency.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import motor.motor_asyncio
+from anyio import create_task_group
 
 from beanie import Document, init_beanie
 
@@ -31,5 +32,7 @@ class TestConcurrency:
                 docs = await SampleModel2.find(SampleModel2.i == 10).to_list()
                 return docs
 
-            await asyncio.gather(*[insert_find() for _ in range(10)])
+            async with create_task_group() as tg:
+                for _ in range(10):
+                    tg.start_soon(insert_find)
         await SampleModel2.delete_all()


### PR DESCRIPTION
Rationale

gather does not cancel other running tasks.

using structured concurency (aka TaskGroup) will cancel running if any of  corutines in same group fails.
This avoid unnecesary and unexpected memory leak performance because we will be running "zombie" tasks we no longer need throwing out results.

blurb from python documentation 
![image](https://github.com/user-attachments/assets/e40fa55d-8bce-4344-b8a3-7c54fc2f1a53)
this is awailible in [python 3.12](https://docs.python.org/3/library/asyncio-task.html#asyncio.TaskGroup) and equivalent in [trio](https://trio.readthedocs.io/en/stable/reference-core.html#nurseries-and-spawning)