### PR TITLE
Fix serialization of Link/BackLink and OpenAPI schema generation

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -529,7 +529,7 @@ class BackLink(Generic[T]):
         def __get_pydantic_core_schema__(
             cls, source_type: Type[Any], handler: GetCoreSchemaHandler
         ) -> CoreSchema:
-            # Note: BackLink's are only virtual fields, they shouldn't be serialized nor appear in the schema.
+            # NOTE: BackLinks are only virtual fields, they shouldn't be serialized nor appear in the schema.
             return json_or_python_schema(
                 python_schema=with_info_plain_validator_function(
                     cls.wrapped_validate(source_type, handler)

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -50,28 +50,28 @@ if IS_PYDANTIC_V2:
         TypeAdapter,
     )
     from pydantic.json_schema import JsonSchemaValue
-    from pydantic_core import CoreSchema, core_schema
     from pydantic_core.core_schema import (
+        CoreSchema,
         ValidationInfo,
+        any_schema,
+        dict_schema,
+        json_or_python_schema,
+        no_info_after_validator_function,
+        no_info_plain_validator_function,
+        plain_serializer_function_ser_schema,
         simple_ser_schema,
+        str_schema,
+        typed_dict_field,
+        typed_dict_schema,
+        union_schema,
+        with_info_plain_validator_function,
     )
 else:
-    from pydantic.fields import ModelField  # type: ignore
+    from pydantic.fields import ModelField
     from pydantic.json import ENCODERS_BY_TYPE
 
 if TYPE_CHECKING:
     from beanie.odm.documents import DocType
-
-if IS_PYDANTIC_V2:
-    plain_validator = (
-        core_schema.with_info_plain_validator_function
-        if hasattr(core_schema, "with_info_plain_validator_function")
-        else core_schema.general_plain_validator_function
-    )
-else:
-
-    def plain_validator(v):
-        return v
 
 
 @dataclass(frozen=True)
@@ -111,17 +111,16 @@ def Indexed(typ=None, index_type=ASCENDING, **kwargs: Any):
 
             @classmethod
             def __get_pydantic_core_schema__(
-                cls, _source_type: Any, _handler: GetCoreSchemaHandler
-            ) -> core_schema.CoreSchema:
+                cls, _source_type: Type[Any], _handler: GetCoreSchemaHandler
+            ) -> CoreSchema:
                 custom_type = getattr(
                     typ, "__get_pydantic_core_schema__", None
                 )
                 if custom_type is not None:
                     return custom_type(_source_type, _handler)
 
-                return core_schema.no_info_after_validator_function(
-                    lambda v: v,
-                    simple_ser_schema(typ.__name__),
+                return no_info_after_validator_function(
+                    lambda v: v, simple_ser_schema(typ.__name__)
                 )
 
     NewType.__name__ = f"Indexed {typ.__name__}"
@@ -134,46 +133,42 @@ class PydanticObjectId(ObjectId):
     """
 
     @classmethod
-    def __get_validators__(cls):
-        yield cls.validate
+    def _validate(cls, v):
+        if isinstance(v, bytes):
+            v = v.decode("utf-8")
+        try:
+            return PydanticObjectId(v)
+        except (InvalidId, TypeError):
+            raise ValueError("Id must be of type PydanticObjectId")
 
     if IS_PYDANTIC_V2:
 
         @classmethod
-        def validate(cls, v, _: ValidationInfo):
-            if isinstance(v, bytes):
-                v = v.decode("utf-8")
-            try:
-                return PydanticObjectId(v)
-            except (InvalidId, TypeError):
-                raise ValueError("Id must be of type PydanticObjectId")
-
-        @classmethod
         def __get_pydantic_core_schema__(
-            cls, source_type: Any, handler: GetCoreSchemaHandler
-        ) -> CoreSchema:  # type: ignore
-            return core_schema.json_or_python_schema(
-                python_schema=plain_validator(cls.validate),
-                json_schema=plain_validator(
-                    cls.validate,
+            cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+        ) -> CoreSchema:
+            return json_or_python_schema(
+                python_schema=no_info_plain_validator_function(cls._validate),
+                json_schema=no_info_plain_validator_function(
+                    cls._validate,
                     metadata={
-                        "pydantic_js_input_core_schema": core_schema.str_schema(
+                        "pydantic_js_input_core_schema": str_schema(
                             pattern="^[0-9a-f]{24}$",
                             min_length=24,
                             max_length=24,
                         )
                     },
                 ),
-                serialization=core_schema.plain_serializer_function_ser_schema(
-                    lambda instance: str(instance), when_used="json"
+                serialization=plain_serializer_function_ser_schema(
+                    lambda instance: str(instance),
+                    return_schema=str_schema(),
+                    when_used="json",
                 ),
             )
 
         @classmethod
         def __get_pydantic_json_schema__(
-            cls,
-            schema: core_schema.CoreSchema,
-            handler: GetJsonSchemaHandler,  # type: ignore
+            cls, schema: CoreSchema, handler: GetJsonSchemaHandler
         ) -> JsonSchemaValue:
             json_schema = handler(schema)
             json_schema.update(
@@ -185,16 +180,11 @@ class PydanticObjectId(ObjectId):
     else:
 
         @classmethod
-        def validate(cls, v):
-            if isinstance(v, bytes):
-                v = v.decode("utf-8")
-            try:
-                return PydanticObjectId(v)
-            except InvalidId:
-                raise TypeError("Id must be of type PydanticObjectId")
+        def __get_validators__(cls):
+            yield cls._validate
 
         @classmethod
-        def __modify_schema__(cls, field_schema):
+        def __modify_schema__(cls, field_schema: Dict[str, Any]):
             field_schema.update(
                 type="string",
                 example="5eb7cf5a86d9755df3a6c593",
@@ -303,19 +293,21 @@ class Link(Generic[T]):
         self.ref = ref
         self.document_class = document_class
 
-    async def fetch(self, fetch_links: bool = False) -> Union[T, Link]:
+    async def fetch(self, fetch_links: bool = False) -> Union[T, Link[T]]:
         result = await self.document_class.get(  # type: ignore
             self.ref.id, with_children=True, fetch_links=fetch_links
         )
         return result or self
 
     @classmethod
-    async def fetch_one(cls, link: Link):
+    async def fetch_one(cls, link: Link[T]):
         return await link.fetch()
 
     @classmethod
     async def fetch_list(
-        cls, links: List[Union[Link, DocType]], fetch_links: bool = False
+        cls,
+        links: List[Union[Link[T], DocType]],
+        fetch_links: bool = False,
     ):
         """
         Fetch list that contains links and documents
@@ -351,7 +343,7 @@ class Link(Generic[T]):
 
     @staticmethod
     def repack_links(
-        links: List[Union[Link, DocType]],
+        links: List[Union[Link[T], DocType]],
     ) -> OrderedDictType[Any, Any]:
         result = OrderedDict()
         for link in links:
@@ -362,7 +354,7 @@ class Link(Generic[T]):
         return result
 
     @classmethod
-    async def fetch_many(cls, links: List[Link]):
+    async def fetch_many(cls, links: List[Link[T]]) -> List[Union[T, Link[T]]]:
         coros = []
         for link in links:
             coros.append(link.fetch())
@@ -371,17 +363,22 @@ class Link(Generic[T]):
     if IS_PYDANTIC_V2:
 
         @staticmethod
-        def serialize(value: Union[Link, BaseModel]):
+        def serialize(value: Union[Link[T], BaseModel]):
             if isinstance(value, Link):
                 return value.to_dict()
             return value.model_dump(mode="json")
 
         @classmethod
-        def build_validation(cls, handler, source_type):
-            def validate(v: Union[DBRef, T], validation_info: ValidationInfo):
-                document_class = DocsRegistry.evaluate_fr(
+        def wrapped_validate(
+            cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+        ):
+            def validate(
+                v: Union[Link[T], T, DBRef, dict[str, Any]],
+                validation_info: ValidationInfo,
+            ) -> Link[T] | T:
+                document_class = DocsRegistry.evaluate_fr(  # type: ignore
                     get_args(source_type)[0]
-                )  # type: ignore  # noqa: F821
+                )
 
                 if isinstance(v, DBRef):
                     return cls(ref=v, document_class=document_class)
@@ -399,6 +396,8 @@ class Link(Generic[T]):
                     )
                 if isinstance(v, dict) or isinstance(v, BaseModel):
                     return parse_obj(document_class, v)
+
+                # Default fallback case for unknown type
                 new_id = TypeAdapter(
                     document_class.model_fields["id"].annotation
                 ).validate_python(v)
@@ -411,25 +410,29 @@ class Link(Generic[T]):
 
         @classmethod
         def __get_pydantic_core_schema__(
-            cls, source_type: Any, handler: GetCoreSchemaHandler
-        ) -> CoreSchema:  # type: ignore
-            return core_schema.json_or_python_schema(
-                python_schema=plain_validator(
-                    cls.build_validation(handler, source_type)
+            cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+        ) -> CoreSchema:
+            return json_or_python_schema(
+                python_schema=with_info_plain_validator_function(
+                    cls.wrapped_validate(source_type, handler)
                 ),
-                json_schema=core_schema.typed_dict_schema(
-                    {
-                        "id": core_schema.typed_dict_field(
-                            core_schema.str_schema()
+                json_schema=union_schema(
+                    [
+                        typed_dict_schema(
+                            {
+                                "id": typed_dict_field(str_schema()),
+                                "collection": typed_dict_field(str_schema()),
+                            }
                         ),
-                        "collection": core_schema.typed_dict_field(
-                            core_schema.str_schema()
+                        dict_schema(
+                            keys_schema=str_schema(),
+                            values_schema=any_schema(),
                         ),
-                    }
+                    ]
                 ),
-                serialization=core_schema.plain_serializer_function_ser_schema(  # type: ignore
-                    lambda instance: cls.serialize(instance),
-                    when_used="json",  # type: ignore
+                serialization=plain_serializer_function_ser_schema(
+                    function=lambda instance: cls.serialize(instance),
+                    when_used="json-unless-none",
                 ),
             )
 
@@ -437,17 +440,26 @@ class Link(Generic[T]):
 
         @classmethod
         def __get_validators__(cls):
-            yield cls.validate
+            yield cls._validate
 
         @classmethod
-        def validate(cls, v: Union[DBRef, T], field: ModelField):
-            document_class = field.sub_fields[0].type_  # type: ignore
+        def _validate(
+            cls,
+            v: Union[Link[T], T, DBRef, dict[str, Any]],
+            field: ModelField,
+        ) -> Link[T] | T:
+            document_class = DocsRegistry.evaluate_fr(  # type: ignore
+                field.sub_fields[0].type_
+            )
+
             if isinstance(v, DBRef):
                 return cls(ref=v, document_class=document_class)
             if isinstance(v, Link):
                 return v
             if isinstance(v, dict) or isinstance(v, BaseModel):
                 return parse_obj(document_class, v)
+
+            # Default fallback case for unknown type
             new_id = parse_object_as(
                 get_field_type(get_model_fields(document_class)["id"]), v
             )
@@ -455,6 +467,28 @@ class Link(Generic[T]):
                 collection=document_class.get_collection_name(), id=new_id
             )
             return cls(ref=ref, document_class=document_class)
+
+        @classmethod
+        def __modify_schema__(cls, field_schema: Dict[str, Any]):
+            field_schema.clear()
+            field_schema.update(
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "id": {"type": "string", "title": "Id"},
+                                "collection": {
+                                    "type": "string",
+                                    "title": "Collection",
+                                },
+                            },
+                            "type": "object",
+                            "required": ["id", "collection"],
+                        },
+                        {"type": "object"},
+                    ],
+                }
+            )
 
     def to_ref(self):
         return self.ref
@@ -476,11 +510,15 @@ class BackLink(Generic[T]):
     if IS_PYDANTIC_V2:
 
         @classmethod
-        def build_validation(cls, handler, source_type):
-            def validate(v: Union[DBRef, T], field):
-                document_class = DocsRegistry.evaluate_fr(
+        def wrapped_validate(
+            cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+        ):
+            def validate(
+                v: Union[T, dict[str, Any]], validation_info: ValidationInfo
+            ) -> BackLink[T] | T:
+                document_class = DocsRegistry.evaluate_fr(  # type: ignore
                     get_args(source_type)[0]
-                )  # type: ignore  # noqa: F821
+                )
                 if isinstance(v, dict) or isinstance(v, BaseModel):
                     return parse_obj(document_class, v)
                 return cls(document_class=document_class)
@@ -489,25 +527,66 @@ class BackLink(Generic[T]):
 
         @classmethod
         def __get_pydantic_core_schema__(
-            cls, source_type: Any, handler: GetCoreSchemaHandler
-        ) -> CoreSchema:  # type: ignore
-            return plain_validator(cls.build_validation(handler, source_type))
+            cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+        ) -> CoreSchema:
+            # Note: BackLink's are only virtual fields, they shouldn't be serialized nor appear in the schema.
+            return json_or_python_schema(
+                python_schema=with_info_plain_validator_function(
+                    cls.wrapped_validate(source_type, handler)
+                ),
+                json_schema=dict_schema(
+                    keys_schema=str_schema(),
+                    values_schema=any_schema(),
+                ),
+                serialization=plain_serializer_function_ser_schema(
+                    lambda instance: cls.to_dict(instance),
+                    return_schema=dict_schema(),
+                    when_used="json-unless-none",
+                ),
+            )
 
     else:
 
         @classmethod
         def __get_validators__(cls):
-            yield cls.validate
+            yield cls._validate
 
         @classmethod
-        def validate(cls, v: Union[DBRef, T], field: ModelField):
-            document_class = field.sub_fields[0].type_  # type: ignore
+        def _validate(
+            cls, v: Union[T, dict[str, Any]], field: ModelField
+        ) -> BackLink[T] | T:
+            document_class = DocsRegistry.evaluate_fr(  # type: ignore
+                field.sub_fields[0].type_
+            )
             if isinstance(v, dict) or isinstance(v, BaseModel):
                 return parse_obj(document_class, v)
             return cls(document_class=document_class)
 
-    def to_dict(self):
-        return {"collection": self.document_class.get_collection_name()}
+        @classmethod
+        def __modify_schema__(cls, field_schema: Dict[str, Any]):
+            field_schema.clear()
+            field_schema.update(
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "id": {"type": "string", "title": "Id"},
+                                "collection": {
+                                    "type": "string",
+                                    "title": "Collection",
+                                },
+                            },
+                            "type": "object",
+                            "required": ["id", "collection"],
+                        },
+                        {"type": "object"},
+                    ],
+                }
+            )
+
+    def to_dict(self) -> dict[str, str]:
+        document_class = DocsRegistry.evaluate_fr(self.document_class)  # type: ignore
+        return {"collection": document_class.get_collection_name()}
 
 
 if not IS_PYDANTIC_V2:
@@ -584,29 +663,23 @@ class IndexModelField:
         left_dict.update(right_dict)
         return list(left_dict.values())
 
+    @classmethod
+    def _validate(cls, v: Any) -> "IndexModelField":
+        if isinstance(v, IndexModel):
+            return IndexModelField(v)
+        else:
+            return IndexModelField(IndexModel(v))
+
     if IS_PYDANTIC_V2:
 
         @classmethod
         def __get_pydantic_core_schema__(
-            cls, source_type: Any, handler: GetCoreSchemaHandler
-        ) -> CoreSchema:  # type: ignore
-            def validate(v, _):
-                if isinstance(v, IndexModel):
-                    return IndexModelField(v)
-                else:
-                    return IndexModelField(IndexModel(v))
-
-            return plain_validator(validate)
+            cls, source_type: Type[Any], handler: GetCoreSchemaHandler
+        ) -> CoreSchema:
+            return no_info_plain_validator_function(cls._validate)
 
     else:
 
         @classmethod
         def __get_validators__(cls):
-            yield cls.validate
-
-        @classmethod
-        def validate(cls, v):
-            if isinstance(v, IndexModel):
-                return IndexModelField(v)
-            else:
-                return IndexModelField(IndexModel(v))
+            yield cls._validate

--- a/tests/fastapi/app.py
+++ b/tests/fastapi/app.py
@@ -5,7 +5,14 @@ from fastapi import FastAPI
 
 from beanie import init_beanie
 from tests.conftest import Settings
-from tests.fastapi.models import DoorAPI, HouseAPI, RoofAPI, WindowAPI
+from tests.fastapi.models import (
+    DoorAPI,
+    House,
+    HouseAPI,
+    Person,
+    RoofAPI,
+    WindowAPI,
+)
 from tests.fastapi.routes import house_router
 
 
@@ -17,7 +24,7 @@ async def live_span(_: FastAPI):
     # INIT BEANIE
     await init_beanie(
         client.beanie_db,
-        document_models=[HouseAPI, WindowAPI, DoorAPI, RoofAPI],
+        document_models=[House, Person, HouseAPI, WindowAPI, DoorAPI, RoofAPI],
     )
     yield
 

--- a/tests/fastapi/conftest.py
+++ b/tests/fastapi/conftest.py
@@ -3,7 +3,14 @@ from asgi_lifespan import LifespanManager
 from httpx import ASGITransport, AsyncClient
 
 from tests.fastapi.app import app
-from tests.fastapi.models import DoorAPI, HouseAPI, RoofAPI, WindowAPI
+from tests.fastapi.models import (
+    DoorAPI,
+    House,
+    HouseAPI,
+    Person,
+    RoofAPI,
+    WindowAPI,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +26,7 @@ async def api_client(clean_db):
 
 @pytest.fixture(autouse=True)
 async def clean_db(db):
-    models = [HouseAPI, WindowAPI, DoorAPI, RoofAPI]
+    models = [House, Person, HouseAPI, WindowAPI, DoorAPI, RoofAPI]
     yield None
 
     for model in models:

--- a/tests/fastapi/models.py
+++ b/tests/fastapi/models.py
@@ -1,6 +1,10 @@
 from typing import List
 
+from pydantic import Field
+
 from beanie import Document, Indexed, Link
+from beanie.odm.fields import BackLink
+from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
 
 
 class WindowAPI(Document):
@@ -20,3 +24,17 @@ class HouseAPI(Document):
     windows: List[Link[WindowAPI]]
     name: Indexed(str)
     height: Indexed(int) = 2
+
+
+class House(Document):
+    name: str
+    owner: Link["Person"]
+
+
+class Person(Document):
+    name: str
+    house: BackLink[House] = (
+        Field(json_schema_extra={"original_field": "owner"})
+        if IS_PYDANTIC_V2
+        else Field(original_field="owner")
+    )

--- a/tests/fastapi/routes.py
+++ b/tests/fastapi/routes.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Body, status
 from pydantic import BaseModel
 
 from beanie import PydanticObjectId, WriteRules
 from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
-from tests.fastapi.models import HouseAPI, WindowAPI
+from tests.fastapi.models import House, HouseAPI, Person, WindowAPI
 
 house_router = APIRouter()
 if not IS_PYDANTIC_V2:
@@ -50,4 +50,17 @@ async def create_houses_with_window_link(window: WindowInput):
 @house_router.post("/houses_2/", response_model=HouseAPI)
 async def create_houses_2(house: HouseAPI):
     await house.insert(link_rule=WriteRules.WRITE)
+    return house
+
+
+@house_router.post(
+    "/house",
+    response_model=House,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_house_new(house: House = Body(...)):
+    person = Person(name="Bob")
+    house.owner = person
+    await house.save(link_rule=WriteRules.WRITE)
+    await house.sync()
     return house

--- a/tests/fastapi/test_api.py
+++ b/tests/fastapi/test_api.py
@@ -43,3 +43,16 @@ async def test_revision_id(api_client):
     resp_json = resp.json()
     assert "revision_id" not in resp_json
     assert resp_json == {"x": 10, "y": 20, "_id": resp_json["_id"]}
+
+
+async def test_create_house_new(api_client):
+    payload = {
+        "name": "FreshHouse",
+        "owner": {"name": "will_be_overridden_to_Bob"},
+    }
+    resp = await api_client.post("/v1/house", json=payload)
+    resp_json = resp.json()
+
+    assert resp_json["name"] == payload["name"]
+    assert resp_json["owner"]["name"] == payload["owner"]["name"][-3:]
+    assert resp_json["owner"]["house"]["collection"] == "House"

--- a/tests/fastapi/test_openapi_schema_generation.py
+++ b/tests/fastapi/test_openapi_schema_generation.py
@@ -1,0 +1,19 @@
+from json import dumps
+
+from fastapi.openapi.utils import get_openapi
+
+from tests.fastapi.app import app
+
+
+def test_openapi_schema_generation():
+    openapi_schema_json_str = dumps(
+        get_openapi(
+            title=app.title,
+            version=app.version,
+            openapi_version=app.openapi_version,
+            description=app.description,
+            routes=app.routes,
+        ),
+    )
+
+    assert openapi_schema_json_str is not None

--- a/tests/odm/test_beanie_object_dumping.py
+++ b/tests/odm/test_beanie_object_dumping.py
@@ -1,3 +1,4 @@
+import pytest
 from pydantic import BaseModel, Field
 
 from beanie import Link, PydanticObjectId
@@ -19,15 +20,21 @@ def data_maker():
     )
 
 
+@pytest.mark.skipif(
+    not IS_PYDANTIC_V2,
+    reason="model dumping support is more complete with pydantic v2",
+)
 def test_id_types_preserved_when_dumping_to_python():
-    if IS_PYDANTIC_V2:
-        dumped = data_maker().model_dump(mode="python")
-        assert isinstance(dumped["my_id"], PydanticObjectId)
-        assert isinstance(dumped["fake_doc"]["id"], PydanticObjectId)
+    dumped = data_maker().model_dump(mode="python")
+    assert isinstance(dumped["my_id"], PydanticObjectId)
+    assert isinstance(dumped["fake_doc"]["id"], PydanticObjectId)
 
 
+@pytest.mark.skipif(
+    not IS_PYDANTIC_V2,
+    reason="model dumping support is more complete with pydantic v2",
+)
 def test_id_types_serialized_when_dumping_to_json():
-    if IS_PYDANTIC_V2:
-        dumped = data_maker().model_dump(mode="json")
-        assert isinstance(dumped["my_id"], str)
-        assert isinstance(dumped["fake_doc"]["id"], str)
+    dumped = data_maker().model_dump(mode="json")
+    assert isinstance(dumped["my_id"], str)
+    assert isinstance(dumped["fake_doc"]["id"], str)

--- a/tests/odm/test_id.py
+++ b/tests/odm/test_id.py
@@ -8,6 +8,10 @@ from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
 from tests.odm.models import DocumentWithCustomIdInt, DocumentWithCustomIdUUID
 
 
+class A(BaseModel):
+    id: PydanticObjectId
+
+
 async def test_uuid_id():
     doc = DocumentWithCustomIdUUID(name="TEST")
     await doc.insert()
@@ -22,28 +26,30 @@ async def test_integer_id():
     assert isinstance(new_doc.id, int)
 
 
-if IS_PYDANTIC_V2:
+@pytest.mark.skipif(
+    not IS_PYDANTIC_V2,
+    reason="supports only pydantic v2",
+)
+async def test_pydantic_object_id_validation_json():
+    deserialized = A.model_validate_json('{"id": "5eb7cf5a86d9755df3a6c593"}')
+    assert isinstance(deserialized.id, PydanticObjectId)
+    assert str(deserialized.id) == "5eb7cf5a86d9755df3a6c593"
+    assert deserialized.id == PydanticObjectId("5eb7cf5a86d9755df3a6c593")
 
-    class A(BaseModel):
-        id: PydanticObjectId
 
-    async def test_pydantic_object_id_validation_json():
-        deserialized = A.model_validate_json(
-            '{"id": "5eb7cf5a86d9755df3a6c593"}'
-        )
-        assert isinstance(deserialized.id, PydanticObjectId)
-        assert str(deserialized.id) == "5eb7cf5a86d9755df3a6c593"
-        assert deserialized.id == PydanticObjectId("5eb7cf5a86d9755df3a6c593")
-
-    @pytest.mark.parametrize(
-        "data",
-        [
-            "5eb7cf5a86d9755df3a6c593",
-            PydanticObjectId("5eb7cf5a86d9755df3a6c593"),
-        ],
-    )
-    async def test_pydantic_object_id_serialization(data):
-        deserialized = A(**{"id": data})
-        assert isinstance(deserialized.id, PydanticObjectId)
-        assert str(deserialized.id) == "5eb7cf5a86d9755df3a6c593"
-        assert deserialized.id == PydanticObjectId("5eb7cf5a86d9755df3a6c593")
+@pytest.mark.skipif(
+    not IS_PYDANTIC_V2,
+    reason="supports only pydantic v2",
+)
+@pytest.mark.parametrize(
+    "data",
+    [
+        "5eb7cf5a86d9755df3a6c593",
+        PydanticObjectId("5eb7cf5a86d9755df3a6c593"),
+    ],
+)
+async def test_pydantic_object_id_serialization(data):
+    deserialized = A(**{"id": data})
+    assert isinstance(deserialized.id, PydanticObjectId)
+    assert str(deserialized.id) == "5eb7cf5a86d9755df3a6c593"
+    assert deserialized.id == PydanticObjectId("5eb7cf5a86d9755df3a6c593")

--- a/tests/odm/test_json_schema_generation.py
+++ b/tests/odm/test_json_schema_generation.py
@@ -1,0 +1,172 @@
+from uuid import uuid4
+
+import pytest
+
+from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
+from tests.odm.models import (
+    DocumentWithBackLink,
+    DocumentWithDecimalField,
+    DocumentWithIndexedObjectId,
+    DocumentWithLink,
+    DocumentWithListBackLink,
+    DocumentWithListLink,
+    DocumentWithOptionalLink,
+)
+
+
+def test_schema_export_of_model_with_decimal_field():
+    doc = DocumentWithDecimalField(amt=0.1, other_amt=3.5)
+    if IS_PYDANTIC_V2:
+        json_schema = doc.model_json_schema()
+
+        assert json_schema["properties"]["amt"]["anyOf"][0]["type"] == "number"
+        assert json_schema["properties"]["amt"]["anyOf"][1]["type"] == "string"
+        assert (
+            json_schema["properties"]["other_amt"]["anyOf"][0]["type"]
+            == "number"
+        )
+        assert (
+            json_schema["properties"]["other_amt"]["anyOf"][1]["type"]
+            == "string"
+        )
+
+    else:
+        json_schema = doc.schema()
+
+        assert json_schema["properties"]["amt"]["type"] == "number"
+        assert json_schema["properties"]["other_amt"]["type"] == "number"
+
+
+def test_schema_export_of_model_with_pydanticobjectid():
+    doc = DocumentWithIndexedObjectId(
+        pyid="5f8d0a8b0b7e3a1e4c9f4b1e", uuid=uuid4(), email="test@test.com"
+    )
+    if IS_PYDANTIC_V2:
+        json_schema = doc.model_json_schema()
+
+        assert json_schema["properties"]["_id"]["anyOf"][0]["type"] == "string"
+        assert json_schema["properties"]["pyid"]["type"] == "string"
+    else:
+        json_schema = doc.schema()
+
+        assert json_schema["properties"]["_id"]["type"] == "string"
+        assert json_schema["properties"]["pyid"]["type"] == "string"
+
+
+def test_schema_export_of_model_with_link():
+    if IS_PYDANTIC_V2:
+        json_schema = DocumentWithLink.model_json_schema()
+
+        link_alternate_representation = json_schema["properties"]["link"][
+            "anyOf"
+        ]
+    else:
+        json_schema = DocumentWithLink.schema()
+
+        link_alternate_representation = json_schema["definitions"][
+            "DocumentWithLink"
+        ]["properties"]["link"]["anyOf"]
+
+    assert link_alternate_representation[0]["type"] == "object"
+    assert link_alternate_representation[1]["type"] == "object"
+
+
+@pytest.mark.skipif(
+    not IS_PYDANTIC_V2,
+    reason="schema dumping support is more complete with pydantic v2",
+)
+def test_schema_export_of_model_with_optional_link():
+    if IS_PYDANTIC_V2:
+        json_schema = DocumentWithOptionalLink.model_json_schema()
+    else:
+        json_schema = DocumentWithOptionalLink.schema()
+
+    link_alternate_representation = json_schema["properties"]["link"]["anyOf"]
+    assert link_alternate_representation[0]["type"] == "object"
+    assert link_alternate_representation[1]["type"] == "object"
+    assert link_alternate_representation[2]["type"] == "null"
+
+
+def test_schema_export_of_model_with_list_link():
+    if IS_PYDANTIC_V2:
+        json_schema = DocumentWithListLink.model_json_schema()
+
+        link_alternate_representation = json_schema["properties"]["link"][
+            "items"
+        ]["anyOf"]
+        link_definition = json_schema["properties"]["link"]["type"]
+    else:
+        json_schema = DocumentWithListLink.schema()
+
+        link_alternate_representation = json_schema["definitions"][
+            "DocumentWithListLink"
+        ]["properties"]["link"]["items"]["anyOf"]
+        link_definition = json_schema["definitions"]["DocumentWithListLink"][
+            "properties"
+        ]["link"]["type"]
+
+    assert link_definition == "array"
+    assert link_alternate_representation[0]["type"] == "object"
+    assert link_alternate_representation[1]["type"] == "object"
+
+
+def test_schema_export_of_model_with_backlink():
+    if IS_PYDANTIC_V2:
+        json_schema = DocumentWithBackLink.model_json_schema()
+
+        back_link_definition = json_schema["properties"]["back_link"]["type"]
+    else:
+        json_schema = DocumentWithBackLink.schema()
+
+        back_link_definition = json_schema["definitions"][
+            "DocumentWithBackLink"
+        ]["properties"]["back_link"]["anyOf"][1]["type"]
+
+    assert back_link_definition == "object"
+
+
+def test_schema_export_of_model_with_list_backlink():
+    if IS_PYDANTIC_V2:
+        json_schema = DocumentWithListBackLink.model_json_schema()
+
+        assert json_schema["properties"]["back_link"]["type"] == "array"
+        assert (
+            json_schema["properties"]["back_link"]["items"]["type"] == "object"
+        )
+    else:
+        json_schema = DocumentWithListBackLink.schema()
+
+        assert (
+            json_schema["definitions"]["DocumentWithListBackLink"][
+                "properties"
+            ]["back_link"]["type"]
+            == "array"
+        )
+        assert (
+            json_schema["definitions"]["DocumentWithListBackLink"][
+                "properties"
+            ]["back_link"]["items"]["anyOf"][1]["type"]
+            == "object"
+        )
+
+
+@pytest.mark.skipif(
+    not IS_PYDANTIC_V2,
+    reason="schema dumping support is more complete with pydantic v2",
+)
+@pytest.mark.parametrize(
+    "model_type",
+    [
+        DocumentWithDecimalField,
+        DocumentWithIndexedObjectId,
+        DocumentWithLink,
+        DocumentWithOptionalLink,
+        DocumentWithListLink,
+        DocumentWithBackLink,
+        DocumentWithListBackLink,
+    ],
+)
+def test_json_serialization_of_model(model_type):
+    validation_schema = model_type.model_json_schema(mode="serialization")
+    assert validation_schema is not None
+    assert isinstance(validation_schema, dict)

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -169,10 +169,12 @@ class TestInsert:
 
         house = parse_model(House, house_not_inserted)
         await house.insert(link_rule=WriteRules.WRITE)
+
         if IS_PYDANTIC_V2:
-            house.model_dump_json()
+            json_str = house.model_dump_json()
         else:
-            house.json()
+            json_str = house.json()
+        assert json_str is not None
 
     async def test_multi_insert_links(self):
         house = House(name="random", windows=[], door=Door())
@@ -195,6 +197,7 @@ class TestInsert:
         assert new_window_2.id is not None
 
     async def test_fetch_after_insert(self, house_not_inserted):
+        # TODO: what is the point of this test if nothing was inserted to DB?
         await house_not_inserted.fetch_all_links()
 
 


### PR DESCRIPTION
Includes and continues upon #1019. Closes #1008. Fixes #199, #982. Possible fix for #1056.

Fixes serialization of Link/BackLink when used in FastAPI routes.
Fixes OpenAPI JSON schema generation to make it work with FastAPI.
Adds forward ref evaluation in some places.
