### PR TITLE
fix: `Owner` model missing in `init_beanie` in Inheritance documentation's Inserts example

### DIFF
--- a/docs/tutorial/inheritance.md
+++ b/docs/tutorial/inheritance.md
@@ -70,7 +70,7 @@ Inserts work the same way as usual
 
 ```python
 client = AsyncIOMotorClient()
-await init_beanie(client.test_db, document_models=[Vehicle, Bicycle, Bike, Car, Bus])
+await init_beanie(client.test_db, document_models=[Vehicle, Bicycle, Bike, Car, Bus, Owner])
 
 bike_1 = await Bike(color='black', fuel='gasoline').insert()
 


### PR DESCRIPTION
Example in documenation is broken, Owner is lost in init