### PR TITLE
Add coverage configuration to pyproject.toml

### DIFF
--- a/beanie/pydantic_check.py
+++ b/beanie/pydantic_check.py
@@ -1,5 +1,0 @@
-import pydantic
-
-
-def is_second_version() -> bool:
-    return int(pydantic.VERSION.split(".")[0]) >= 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,24 @@ beanie = "beanie.executors.migrate:migrations"
 
 # TOOLS
 
+[tool.coverage.run]
+branch = true
+source = ["beanie"]
+
+[tool.coverage.report]
+ignore_errors = true
+show_missing = true
+fail_under = 80
+exclude_lines = [
+    'pragma: no cover',
+    'if TYPE_CHECKING:',
+    'if typing.TYPE_CHECKING:',
+    'if __name__ == .__main__.:'
+]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
-addopts = "--cov-report term-missing --cov=beanie --cov-branch --cov-fail-under=80"
+addopts = "--cov"
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION
Add coverage configuration to pyproject.toml.
Simplify pytest setup and try to increase code coverage by skipping lines that e.g. contain imports when type checking.
Remove beanie/pydantic_check.py as it is unused.