### PR TITLE
Use strings to specify MongoDB versions in CI

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
-        mongodb-version: [4.4, 5.0, 6.0, 7.0, 8.0 ]
+        mongodb-version: [ "4.4", "5.0", "6.0", "7.0", "8.0" ]
         pydantic-version: [ "1.10.18", "2.9.2" ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The [action](https://github.com/supercharge/mongodb-github-action) documents it as strings, and although it seems to work, this might have unexpected effects.