### PR TITLE
fix: pydantic 2.10.x breaking change

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
         mongodb-version: [4.4, 5.0, 6.0, 7.0, 8.0 ]
-        pydantic-version: [ "1.10.18", "2.9.2" ]
+        pydantic-version: [ "1.10.18", "2.9.2", "2.10.4" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -1,5 +1,7 @@
 name: Tests
-on: [ pull_request ]
+on:
+  pull_request:
+  push:
 
 jobs:
   pre-commit:

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -38,6 +38,7 @@ from beanie.odm.registry import DocsRegistry
 from beanie.odm.utils.parsing import parse_obj
 from beanie.odm.utils.pydantic import (
     IS_PYDANTIC_V2,
+    IS_PYDANTIC_V2_10,
     get_field_type,
     get_model_fields,
     parse_object_as,
@@ -147,17 +148,36 @@ class PydanticObjectId(ObjectId):
         def __get_pydantic_core_schema__(
             cls, source_type: Type[Any], handler: GetCoreSchemaHandler
         ) -> CoreSchema:
+            if not IS_PYDANTIC_V2_10:
+                return json_or_python_schema(
+                    python_schema=no_info_plain_validator_function(
+                        cls._validate
+                    ),
+                    json_schema=no_info_plain_validator_function(
+                        cls._validate,
+                        metadata={
+                            "pydantic_js_input_core_schema": str_schema(
+                                pattern="^[0-9a-f]{24}$",
+                                min_length=24,
+                                max_length=24,
+                            )
+                        },
+                    ),
+                    serialization=plain_serializer_function_ser_schema(
+                        lambda instance: str(instance),
+                        return_schema=str_schema(),
+                        when_used="json",
+                    ),
+                )
             return json_or_python_schema(
                 python_schema=no_info_plain_validator_function(cls._validate),
                 json_schema=no_info_plain_validator_function(
                     cls._validate,
-                    metadata={
-                        "pydantic_js_input_core_schema": str_schema(
-                            pattern="^[0-9a-f]{24}$",
-                            min_length=24,
-                            max_length=24,
-                        )
-                    },
+                    json_schema_input_schema=str_schema(
+                        pattern="^[0-9a-f]{24}$",
+                        min_length=24,
+                        max_length=24,
+                    ),
                 ),
                 serialization=plain_serializer_function_ser_schema(
                     lambda instance: str(instance),

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -24,7 +24,11 @@ import pydantic
 
 import beanie
 from beanie.odm.fields import Link, LinkTypes
-from beanie.odm.utils.pydantic import IS_PYDANTIC_V2, get_model_fields
+from beanie.odm.utils.pydantic import (
+    IS_PYDANTIC_V2,
+    IS_PYDANTIC_V2_10,
+    get_model_fields,
+)
 
 SingleArgCallable = Callable[[Any], Any]
 DEFAULT_CUSTOM_ENCODERS: MutableMapping[type, SingleArgCallable] = {
@@ -50,6 +54,11 @@ if IS_PYDANTIC_V2:
     from pydantic_core import Url
 
     DEFAULT_CUSTOM_ENCODERS[Url] = str
+
+if IS_PYDANTIC_V2_10:
+    from pydantic import AnyUrl
+
+    DEFAULT_CUSTOM_ENCODERS[AnyUrl] = str
 
 BSON_SCALAR_TYPES = (
     type(None),

--- a/beanie/odm/utils/pydantic.py
+++ b/beanie/odm/utils/pydantic.py
@@ -1,9 +1,22 @@
 from typing import Any, Type
 
 import pydantic
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 from pydantic import BaseModel
 
-IS_PYDANTIC_V2 = int(pydantic.VERSION.split(".")[0]) >= 2
+
+def is_version_valid(version, requirement):
+    # Parse the requirement as a SpecifierSet
+    specifiers = SpecifierSet(requirement)
+    # Parse the version as a Version
+    v = Version(version)
+    # Check if the version satisfies the specifiers
+    return v in specifiers
+
+
+IS_PYDANTIC_V2 = is_version_valid(pydantic.VERSION, ">=2")
+IS_PYDANTIC_V2_10 = is_version_valid(pydantic.VERSION, ">=2.10")
 
 if IS_PYDANTIC_V2:
     from pydantic import TypeAdapter


### PR DESCRIPTION
Changes:
1. Breaking changes on new url type
2. Breaking changes on `pydantic_core.core_schema.no_info_plain_validator_function`

Known affected test on pydantic latest release:
1. tests/odm/test_encoder.py::test_should_encode_pydantic_v2_url_correctly
2. tests/odm/test_encoder.py::test_should_be_able_to_save_retrieve_doc_with_url
3. tests/odm/test_fields.py::test_revision_id_not_in_schema
4. tests/odm/test_json_schema_generation.py::test_schema_export_of_model_with_decimal_field
5. tests/odm/test_json_schema_generation.py::test_schema_export_of_model_with_pydanticobjectid
6. tests/odm/test_json_schema_generation.py::test_schema_export_of_model_with_link
7. tests/odm/test_json_schema_generation.py
8. tests/odm/test_json_schema_generation.py::test_schema_export_of_model_with_list_link
9. tests/odm/test_json_schema_generation.py::test_schema_export_of_model_with_backlink
10. tests/odm/test_json_schema_generation.py::test_schema_export_of_model_with_list_backlink 

Related issues:
1. Closes #1084 
