### PR TITLE
Refactor/index management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ tilt_modules
 # Poetry stuff
 poetry.lock
 .pdm-python
+
+# macOS
+**/.DS_Store

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -607,21 +607,14 @@ class IndexModelField:
             )
         )
 
+    def __hash__(self) -> int:
+        return hash(self.fields + self.options)
+
     def __eq__(self, other):
         return self.fields == other.fields and self.options == other.options
 
     def __repr__(self):
         return f"IndexModelField({self.name}, {self.fields}, {self.options})"
-
-    @staticmethod
-    def list_difference(
-        left: List[IndexModelField], right: List[IndexModelField]
-    ):
-        result = []
-        for index in left:
-            if index not in right:
-                result.append(index)
-        return result
 
     @staticmethod
     def list_to_index_model(left: List[IndexModelField]):
@@ -653,15 +646,6 @@ class IndexModelField:
             if i.same_fields(index):
                 return i
         return None
-
-    @staticmethod
-    def merge_indexes(
-        left: List[IndexModelField], right: List[IndexModelField]
-    ):
-        left_dict = {index.fields: index for index in left}
-        right_dict = {index.fields: index for index in right}
-        left_dict.update(right_dict)
-        return list(left_dict.values())
 
     @classmethod
     def _validate(cls, v: Any) -> "IndexModelField":

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -616,10 +616,6 @@ class IndexModelField:
     def __repr__(self):
         return f"IndexModelField({self.name}, {self.fields}, {self.options})"
 
-    @staticmethod
-    def list_to_index_model(left: List[IndexModelField]):
-        return [index.index for index in left]
-
     @classmethod
     def from_motor_index_information(cls, index_info: dict):
         result = []

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -552,7 +552,7 @@ class Initializer:
         # create indices
         if found_indexes:
             new_indexes += await collection.create_indexes(
-                IndexModelField.list_to_index_model(new_indexes)
+                [index.index for index in new_indexes]
             )
 
     async def init_document(self, cls: Type[Document]) -> Optional[Output]:


### PR DESCRIPTION
This request improves the readability and maintainability of classes and functions related to index management:

- adds a `__hash__` method to `IndexModelField` to allow set operations on collections of indexes.
- removes limited-use `@staticmethod`s from `IndexModelField` in favour of explicit set operations to reduce verbosity.
- enhances the readability of `init_indexes` function by reducing clutter and using self-explanatory variable names.
