### PR TITLE
Add tests with case of {id} in fastapi path

### DIFF
--- a/tests/fastapi/routes.py
+++ b/tests/fastapi/routes.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import APIRouter, Body, status
 from pydantic import BaseModel
 
@@ -26,6 +28,11 @@ async def create_window(window: WindowAPI):
 @house_router.post("/windows_2/")
 async def create_window_2(window: WindowAPI):
     return await window.save()
+
+
+@house_router.get("/windows/{id}", response_model=Optional[WindowAPI])
+async def get_window(id: PydanticObjectId):
+    return await WindowAPI.get(id)
 
 
 @house_router.post("/houses/", response_model=HouseAPI)

--- a/tests/fastapi/test_api.py
+++ b/tests/fastapi/test_api.py
@@ -9,6 +9,22 @@ async def test_create_window(api_client):
     assert resp_json["y"] == 20
 
 
+async def test_get_window(api_client):
+    payload = {"x": 10, "y": 20}
+    data1 = (
+        (await api_client.post("/v1/windows/", json=payload))
+        .raise_for_status()
+        .json()
+    )
+    window_id = data1["_id"]
+    data2 = (
+        (await api_client.get(f"/v1/windows/{window_id}"))
+        .raise_for_status()
+        .json()
+    )
+    assert data2 == data1
+
+
 async def test_create_house(api_client):
     payload = {"x": 10, "y": 20}
     resp = await api_client.post("/v1/houses/", json=payload)


### PR DESCRIPTION
Now we can see one failing case for schema generation
```
============================================================================== short test summary info ===============================================================================
FAILED tests/fastapi/test_openapi_schema_generation.py::test_openapi_schema_generation - pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.PlainValidatorFunctionSchema ({'type': 'no-info', 'function': <bound method PydanticOb...
============================================================================ 1 failed, 7 passed in 2.05s =============================================================================
```