### PR TITLE
Update toml dependency to use tomli instead of toml

### DIFF
--- a/.github/scripts/handlers/version.py
+++ b/.github/scripts/handlers/version.py
@@ -2,7 +2,8 @@ import subprocess
 from pathlib import Path
 
 import requests  # type: ignore
-import toml
+import tomli
+import tomli_w
 from gh import GitHubHandler
 
 
@@ -57,7 +58,8 @@ class VersionHandler:
 
     @staticmethod
     def parse_version_from_pyproject(pyproject: Path) -> SemVer:
-        toml_data = toml.loads(pyproject.read_text())
+        with pyproject.open("rb") as f:
+            toml_data = tomli.load(f)
         return SemVer(toml_data["project"]["version"])
 
     def get_version_from_pypi(self) -> SemVer:
@@ -74,9 +76,11 @@ class VersionHandler:
         self.update_changelog()
 
     def update_pyproject_version(self):
-        pyproject = toml.loads(self.pyproject.read_text())
+        with self.pyproject.open("rb") as f:
+            pyproject = tomli.load(f)
         pyproject["project"]["version"] = str(self.current_version)
-        self.pyproject.write_text(toml.dumps(pyproject))
+        with self.pyproject.open("wb") as f:
+            tomli_w.dump(pyproject, f)
 
     def update_file_versions(self, files_to_update):
         for file_path in files_to_update:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,4 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-click
-          - types-toml
         exclude: ^tests/

--- a/beanie/executors/migrate.py
+++ b/beanie/executors/migrate.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import click
-import toml
+import tomli
 
 from beanie.migrations import template
 from beanie.migrations.database import DBHandler
@@ -89,9 +89,10 @@ class MigrationSettings:
     def get_from_toml(field_name) -> Any:
         path = Path("pyproject.toml")
         if path.is_file():
+            with path.open("rb") as f:
+                toml_data = tomli.load(f)
             val = (
-                toml.load(path)
-                .get("tool", {})
+                toml_data.get("tool", {})
                 .get("beanie", {})
                 .get("migrations", {})
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pydantic>=1.10.18,<3.0",
     "motor>=2.5.0,<4.0.0",
     "click>=7",
-    "toml",
+    "tomli",
     "lazy-model==0.2.0",
     "typing-extensions>=4.7",
 ]
@@ -56,7 +56,8 @@ doc = [
 ]
 queue = ["beanie-batteries-queue>=0.2"]
 ci = [
-    "toml",
+    "tomli",
+    "tomli-w",
     "requests",
     "types-requests",
 ]
@@ -110,10 +111,6 @@ path = "beanie/example_migration"
 database_name = "beanie_db"
 
 [tool.mypy]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "toml"
 ignore_missing_imports = true
 
 [tool.pyright]

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -1,13 +1,14 @@
 from pathlib import Path
 
-import toml
+import tomli
 
 from beanie import __version__
 
 
 def parse_version_from_pyproject():
     pyproject = Path(__file__).parent.parent / "pyproject.toml"
-    toml_data = toml.loads(pyproject.read_text())
+    with pyproject.open("rb") as f:
+        toml_data = tomli.load(f)
     return toml_data["project"]["version"]
 
 


### PR DESCRIPTION
The toml library beanie uses is years out of date, and [doesn't support the newer toml syntax (from 5 years ago...) of mixing types in arrays](https://github.com/uiri/toml/issues/270). 

When running migrations, beanie uses the toml library to parse config from pyproject.toml. If the pyproject file contains mixed types, such as this valid tox config:

```
[tool.tox.env.precommit]
description = "run pre-commit"
skip_install = true
deps = ["pre-commit"]
commands = [["pre-commit", { replace = "posargs", default = ["run", "--all-files"], extend = true} ]]
```

`beanie migrate -p [...]` will error out with:

    File ".venv/lib/python3.12/site-packages/toml/decoder.py", line 1002, in load_array
      a[b] = a[b] + ',' + a[b + 1]
                          ~^^^^^^^
    IndexError: list index out of range

This PR changes the dependency from toml to tomli (and tomli-w for GH script). It's the most used toml library that provides backports of the builtin tomllib to py3.8.