### PR TITLE
Fix Static Analysis Warning for Method Calls in PyCharm (save(), delete() etc.) Related to Beanie Document Events.

### DIFF
--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -207,7 +207,7 @@ def after_event(
 def wrap_with_actions(
     event_type: EventTypes,
 ) -> Callable[
-    ["AsyncDocMethod[DocType, P, R]"], "AsyncDocMethod[DocType, P, R]"
+    ["AsyncDocMethod[DocType, P, R]"], Optional["AsyncDocMethod[DocType, P, R]"]
 ]:
     """
     Helper function to wrap Document methods with


### PR DESCRIPTION
**Background:**

When developing with PyCharm, PyCharm will show a "`missing parameter`" warning when calling Beanie's Document-related events (such as `save()`, `delete()`, etc.), even though there is no issue when the code runs. This is due to PyCharm's static analysis tool failing to correctly infer the parameter types in some of Beanie's Document methods, leading to false warnings.

**Problem:**

- PyCharm's static analysis fails to recognize the method parameters, resulting in a "missing parameter" warning.

- Although there is no issue during runtime, to eliminate the false warnings in static analysis, I need to adjust the type hints to resolve this (using `type: ignore`).

**Verification:**

- Conduct local development testing in PyCharm to ensure that the "missing parameter" warning no longer appears.

- Ensure that Beanie's related events (such as save() and delete()) are still functioning as expected and working correctly.

**Impact:**

- This change only affects PyCharm's static analysis warnings and does not impact Beanie's runtime behavior.

- The modification is an optimization for the static analysis performed by the development tools, enhancing the development experience.