### PR TITLE
Index merging improvements

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import logging
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
@@ -39,6 +41,15 @@ from beanie.odm.utils.pydantic import get_model_fields
 
 if TYPE_CHECKING:
     from beanie.odm.documents import DocType
+
+logger = logging.getLogger(__name__)
+
+_DIRECTION_NAMES = {1: "ASCENDING", -1: "DESCENDING"}
+
+
+def _direction_name(direction: int) -> str:
+    """Return a human-readable name for a PyMongo direction constant."""
+    return _DIRECTION_NAMES.get(direction, str(direction))
 
 
 @dataclass(frozen=True)
@@ -585,7 +596,6 @@ class IndexModelField:
     def __init__(self, index: IndexModel):
         self.index = index
         self.name = index.document["name"]
-
         self.fields = tuple(sorted(self.index.document["key"]))
         self.options = tuple(
             sorted(
@@ -593,6 +603,26 @@ class IndexModelField:
                 for k, v in self.index.document.items()
                 if k not in ["key", "v"]
             )
+        )
+        # Pre-compute hashable canonical options (excluding name) for
+        # index merge deduplication.
+        # Dict/list values are JSON-serialized with sorted keys for
+        # order-independent comparison.
+        # Result is a flat tuple of (key, value) pairs, e.g.:
+        # _canonical_options =
+        # (
+        #     ("expireAfterSeconds", 30),
+        #     ("partialFilterExpression", '{"status": "pending"}'),
+        # )
+        self._canonical_options = tuple(
+            (
+                k,
+                json.dumps(v, sort_keys=True)
+                if isinstance(v, (dict, list))
+                else v,
+            )
+            for k, v in self.options
+            if k != "name"
         )
 
     def __eq__(self, other):
@@ -644,12 +674,71 @@ class IndexModelField:
 
     @staticmethod
     def merge_indexes(
-        left: list["IndexModelField"], right: list["IndexModelField"]
-    ):
-        left_dict = {index.fields: index for index in left}
-        right_dict = {index.fields: index for index in right}
-        left_dict.update(right_dict)
-        return list(left_dict.values())
+        existing_indexes: list["IndexModelField"],
+        new_indexes: list["IndexModelField"],
+    ) -> list["IndexModelField"]:
+        """Merge two lists of indexes, ensuring no duplicates.
+
+        Deduplication is based on the combination of field paths and index
+        options, with the following rules applied in order of precedence:
+
+        - Same fields, same options (modulo name): the later definition
+            takes precedence.
+        - Same fields, different options: both entries are retained as
+            distinct indexes.
+        - Single-field, direction difference only: treated as the same
+            index; the later definition takes precedence.
+        - Compound, direction difference on any field: treated as distinct
+            indexes; both entries are retained.
+
+        :param existing_indexes: list[IndexModelField] - Existing indexes.
+        :param new_indexes: list[IndexModelField] - New indexes to merge in.
+        :return: list[IndexModelField] - Merged deduplicated list of indexes.
+        """
+        merged: dict[tuple, IndexModelField] = {}
+
+        for index in existing_indexes + new_indexes:
+            key_doc = index.index.document["key"]
+            # Ordered list of (field, direction) pairs
+            items = tuple(key_doc.items())
+
+            if len(items) == 1:
+                # Single-field index: deduplicate regardless of direction,
+                # since MongoDB can satisfy both sort orders from one index.
+                # Warn if two definitions disagree on direction so the
+                # caller is aware one is being silently discarded.
+                field_name, direction = items[0]
+                canonical_fields = (field_name,)
+                canonical_key = (canonical_fields, index._canonical_options)
+
+                if canonical_key in merged:
+                    existing_dir = tuple(
+                        merged[canonical_key].index.document["key"].items()
+                    )[0][1]
+                    if existing_dir != direction:
+                        logger.warning(
+                            "Index on field '%s' is defined with conflicting "
+                            "directions (%s and %s). The later definition will "
+                            "be used. If both directions are needed, use a "
+                            "compound index or define them separately with "
+                            "explicit index names.",
+                            field_name,
+                            _direction_name(existing_dir),
+                            _direction_name(direction),
+                        )
+            else:
+                # Compound index: direction is significant per field because
+                # MongoDB cannot reverse a multi-field index to serve a
+                # query that requires a different per-field sort order.
+                # Keep the exact (field, direction) sequence as the key so
+                # that e.g. [(a, 1), (b, -1)] and [(a, 1), (b, 1)] are
+                # treated as distinct indexes and both are retained.
+                canonical_fields = items
+                canonical_key = (canonical_fields, index._canonical_options)
+
+            merged[canonical_key] = index
+
+        return list(merged.values())
 
     @classmethod
     def _validate(cls, v: Any) -> "IndexModelField":

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -1,5 +1,6 @@
 import importlib
 import inspect
+import logging
 from importlib.metadata import version
 from types import UnionType
 from typing import (  # noqa: UP035
@@ -42,6 +43,8 @@ from beanie.odm.utils.typing import get_index_attributes, is_generic_alias
 from beanie.odm.views import View
 
 _DRIVER_METADATA = DriverInfo(name="beanie", version=version("beanie"))
+
+logger = logging.getLogger(__name__)
 
 
 class Output(BaseModel):
@@ -534,10 +537,20 @@ class Initializer:
             for index in IndexModelField.list_difference(
                 old_indexes, new_indexes
             ):
+                logger.warning(
+                    "%s: Dropping index '%s'", cls.__name__, index.name
+                )
                 await collection.drop_index(index.name)
 
         # create indices
         if found_indexes:
+            for index in found_indexes:
+                logger.debug(
+                    "%s: Creating index '%s' on %s",
+                    cls.__name__,
+                    index.name,
+                    list(index.index.document["key"].keys()),
+                )
             new_indexes += await collection.create_indexes(
                 IndexModelField.list_to_index_model(new_indexes)
             )

--- a/tests/odm/documents/test_indexes.py
+++ b/tests/odm/documents/test_indexes.py
@@ -1,0 +1,670 @@
+"""Comprehensive regression tests for index creation and merging logic.
+
+Covers: IndexModelField equality, merge_indexes deduplication, same-field
+multiple indexes, Annotated/Indexed, aliases, compound/direction conflicts,
+option-order canonicalization, field-level vs Settings interaction, and
+backward compatibility with inheritance-based merge.
+"""
+
+import json
+
+from pymongo import ASCENDING, DESCENDING, AsyncMongoClient, IndexModel
+
+from beanie import Document, Indexed, init_beanie
+from beanie.odm.fields import IndexModelField
+from tests.odm.models import (
+    Color,
+    DocumentTestModelIndexFlagsAnnotated,
+    DocumentTestModelWithComplexIndex,
+    DocumentTestModelWithIndexFlags,
+    DocumentTestModelWithIndexFlagsAliases,
+    DocumentTestModelWithSimpleIndex,
+    DocumentWithCompoundIndexes,
+    DocumentWithCompoundIndexesDirectionConflict,
+    DocumentWithCompoundIndexesFieldOrderConflict,
+    DocumentWithIndexMerging2,
+    DocumentWithMultipleIndexesOnSameField,
+    DocumentWithMultipleIndexesOnSameFieldWithSameOptions,
+    DocumentWithMultipleSameIndexesOptionOrderConflict,
+    DocumentWithMultipleSameIndexesWithDifferentName,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests: IndexModelField equality
+# ---------------------------------------------------------------------------
+
+
+class TestIndexModelFieldEquality:
+    """IndexModelField.__eq__ uses (fields, options) including name."""
+
+    def test_different_names_not_equal(self):
+        field1 = IndexModelField(IndexModel("a", name="idx1"))
+        field2 = IndexModelField(IndexModel("a", name="idx2"))
+        assert field1 != field2
+
+    def test_different_directions_not_equal(self):
+        field1 = IndexModelField(IndexModel([("a", 1)]))
+        field2 = IndexModelField(IndexModel([("a", -1)]))
+        assert field1 != field2
+
+    def test_compound_field_order_not_equal(self):
+        field1 = IndexModelField(IndexModel([("a", 1), ("b", 1)]))
+        field2 = IndexModelField(IndexModel([("b", 1), ("a", 1)]))
+        assert field1 != field2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: merge_indexes pure logic
+# ---------------------------------------------------------------------------
+
+
+class TestMergeIndexesPreservesDifferentOptions:
+    """Two indexes on same field with different options must both survive."""
+
+    def test_different_partial_filters_and_ttl(self):
+        """User's original bug: two TTL indexes on same field with different
+        partialFilterExpression should both be preserved."""
+        index1 = IndexModelField(
+            IndexModel(
+                [("created_at", 1)],
+                name="processing_expire_30",
+                expireAfterSeconds=30,
+                partialFilterExpression={"status": "processing"},
+            )
+        )
+        index2 = IndexModelField(
+            IndexModel(
+                [("created_at", 1)],
+                name="unpaid_expire_900",
+                expireAfterSeconds=900,
+                partialFilterExpression={"status": "unpaid"},
+            )
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+
+        assert len(merged) == 2
+        assert {idx.name for idx in merged} == {
+            "processing_expire_30",
+            "unpaid_expire_900",
+        }
+
+    def test_different_sparse_vs_unique(self):
+        """Same field, one sparse and one unique — both kept."""
+        index1 = IndexModelField(
+            IndexModel([("email", 1)], name="email_sparse", sparse=True)
+        )
+        index2 = IndexModelField(
+            IndexModel([("email", 1)], name="email_unique", unique=True)
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+
+        assert len(merged) == 2
+        assert {idx.name for idx in merged} == {"email_sparse", "email_unique"}
+
+
+class TestMergeIndexesDeduplication:
+    """Indexes with same fields and same options should deduplicate."""
+
+    def test_same_options_different_names_deduplicates(self):
+        """Same field + same options but different names: the last one wins."""
+        index1 = IndexModelField(
+            IndexModel(
+                [("created_at", 1)], name="idx_a", expireAfterSeconds=30
+            )
+        )
+        index2 = IndexModelField(
+            IndexModel(
+                [("created_at", 1)], name="idx_b", expireAfterSeconds=30
+            )
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+
+        assert len(merged) == 1
+        assert merged[0].name == "idx_b"
+
+    def test_identical_indexes_deduplicate(self):
+        index = IndexModelField(IndexModel([("field", 1)], name="field_1"))
+        merged = IndexModelField.merge_indexes([index], [index])
+        assert len(merged) == 1
+
+    def test_right_list_overwrites_left(self):
+        """new_indexes (right) wins over existing_indexes (left)."""
+        index_old = IndexModelField(
+            IndexModel([("x", 1)], name="x_1", unique=True)
+        )
+        index_new = IndexModelField(
+            IndexModel([("x", -1)], name="x_-1", unique=True)
+        )
+
+        merged = IndexModelField.merge_indexes([index_old], [index_new])
+
+        assert len(merged) == 1
+        assert merged[0].name == "x_-1"
+
+
+class TestMergeIndexesSingleFieldDirection:
+    """Single-field indexes ignore direction for dedup purposes."""
+
+    def test_ascending_vs_descending_last_wins(self):
+        index_asc = IndexModelField(IndexModel([("ts", ASCENDING)]))
+        index_desc = IndexModelField(IndexModel([("ts", DESCENDING)]))
+
+        merged = IndexModelField.merge_indexes([index_asc], [index_desc])
+
+        assert len(merged) == 1
+        assert dict(merged[0].index.document["key"])["ts"] == DESCENDING
+
+    def test_direction_ignored_but_options_differentiate(self):
+        """Same field, different direction AND different options → both kept."""
+        index1 = IndexModelField(
+            IndexModel([("ts", ASCENDING)], expireAfterSeconds=60)
+        )
+        index2 = IndexModelField(IndexModel([("ts", DESCENDING)], unique=True))
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+
+        assert len(merged) == 2
+
+
+class TestMergeIndexesCompound:
+    """Compound indexes preserve full (field, direction) ordering in key."""
+
+    def test_same_fields_different_direction_both_kept(self):
+        index1 = IndexModelField(
+            IndexModel([("a", ASCENDING), ("b", ASCENDING)])
+        )
+        index2 = IndexModelField(
+            IndexModel([("a", ASCENDING), ("b", DESCENDING)])
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+        assert len(merged) == 2
+
+    def test_same_fields_different_order_both_kept(self):
+        index1 = IndexModelField(
+            IndexModel([("a", ASCENDING), ("b", ASCENDING)])
+        )
+        index2 = IndexModelField(
+            IndexModel([("b", ASCENDING), ("a", ASCENDING)])
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+        assert len(merged) == 2
+
+    def test_identical_compound_deduplicates(self):
+        index1 = IndexModelField(
+            IndexModel([("a", 1), ("b", -1)], name="ab_idx")
+        )
+        index2 = IndexModelField(
+            IndexModel([("a", 1), ("b", -1)], name="ab_idx_v2")
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+        assert len(merged) == 1
+        assert merged[0].name == "ab_idx_v2"
+
+
+class TestMergeIndexesOptionsCanonicalization:
+    """Options with different key ordering should be treated as equal."""
+
+    def test_partial_filter_key_order_irrelevant(self):
+        index1 = IndexModelField(
+            IndexModel(
+                [("x", 1)],
+                name="idx1",
+                partialFilterExpression={"status": "a", "type": "b"},
+            )
+        )
+        index2 = IndexModelField(
+            IndexModel(
+                [("x", 1)],
+                name="idx2",
+                partialFilterExpression={"type": "b", "status": "a"},
+            )
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+        assert len(merged) == 1
+        assert merged[0].name == "idx2"
+
+    def test_nested_dict_options_canonicalized(self):
+        index1 = IndexModelField(
+            IndexModel(
+                [("x", 1)],
+                name="idx1",
+                partialFilterExpression={"$and": [{"a": 1}, {"b": 2}]},
+            )
+        )
+        index2 = IndexModelField(
+            IndexModel(
+                [("x", 1)],
+                name="idx2",
+                partialFilterExpression={"$and": [{"a": 1}, {"b": 2}]},
+            )
+        )
+
+        merged = IndexModelField.merge_indexes([index1], [index2])
+        assert len(merged) == 1
+
+
+class TestMergeIndexesFieldLevelVsSettings:
+    """Field-level Indexed() merged with Settings indexes."""
+
+    def test_field_indexed_and_settings_ttl_both_kept(self):
+        """Indexed() produces a plain index; Settings adds TTL → both survive."""
+        field_index = IndexModelField(IndexModel([("created_at", 1)]))
+        settings_index = IndexModelField(
+            IndexModel(
+                [("created_at", 1)],
+                name="ttl_idx",
+                expireAfterSeconds=3600,
+            )
+        )
+
+        merged = IndexModelField.merge_indexes([field_index], [settings_index])
+        assert len(merged) == 2
+
+    def test_field_indexed_and_settings_same_options_deduplicates(self):
+        field_index = IndexModelField(IndexModel([("status", 1)], unique=True))
+        settings_index = IndexModelField(
+            IndexModel([("status", 1)], name="status_unique", unique=True)
+        )
+
+        merged = IndexModelField.merge_indexes([field_index], [settings_index])
+        assert len(merged) == 1
+        assert merged[0].name == "status_unique"
+
+
+class TestMergeIndexesBackwardCompat:
+    """Ensures existing merge_indexes behavior from inheritance is preserved."""
+
+    def test_full_merge_scenario(self):
+        """Reproduces the existing DocumentWithIndexMerging1/2 expected behavior."""
+        parent_indexes = [
+            IndexModelField(IndexModel([("s1", ASCENDING)])),
+            IndexModelField(IndexModel([("s2", ASCENDING)])),
+            IndexModelField(IndexModel([("s3", ASCENDING)], name="s3_index")),
+            IndexModelField(IndexModel([("s4", ASCENDING)], name="s4_index")),
+        ]
+        child_indexes = [
+            IndexModelField(IndexModel([("s0", ASCENDING)])),
+            IndexModelField(IndexModel([("s1", ASCENDING)])),
+            IndexModelField(IndexModel([("s2", DESCENDING)])),
+            IndexModelField(IndexModel([("s3", DESCENDING)], name="s3_index")),
+        ]
+
+        merged = IndexModelField.merge_indexes(parent_indexes, child_indexes)
+
+        names = {idx.name for idx in merged}
+        assert "s0_1" in names
+        assert "s1_1" in names
+        assert "s4_index" in names
+        assert "s3_index" in names
+        s2_idx = next(
+            idx
+            for idx in merged
+            if list(idx.index.document["key"].keys()) == ["s2"]
+        )
+        assert dict(s2_idx.index.document["key"])["s2"] == DESCENDING
+
+
+class TestMergeIndexesEmptyInputs:
+    def test_both_empty(self):
+        assert IndexModelField.merge_indexes([], []) == []
+
+    def test_left_empty(self):
+        idx = IndexModelField(IndexModel([("a", 1)]))
+        assert len(IndexModelField.merge_indexes([], [idx])) == 1
+
+    def test_right_empty(self):
+        idx = IndexModelField(IndexModel([("a", 1)]))
+        assert len(IndexModelField.merge_indexes([idx], [])) == 1
+
+
+class TestCanonicalOptions:
+    """Tests for pre-computed _canonical_options on IndexModelField."""
+
+    def test_dict_option_canonicalized_via_json(self):
+        idx = IndexModelField(
+            IndexModel(
+                [("x", 1)],
+                name="idx",
+                partialFilterExpression={"b": 2, "a": 1},
+            )
+        )
+        # Dict value should be a JSON string with sorted keys
+        opt_dict = dict(idx._canonical_options)
+        assert opt_dict["partialFilterExpression"] == '{"a": 1, "b": 2}'
+
+    def test_primitive_options_unchanged(self):
+        idx = IndexModelField(
+            IndexModel([("x", 1)], name="idx", unique=True, sparse=True)
+        )
+        opt_dict = dict(idx._canonical_options)
+        assert opt_dict["unique"] is True
+        assert opt_dict["sparse"] is True
+
+    def test_name_excluded_from_canonical(self):
+        idx = IndexModelField(
+            IndexModel([("x", 1)], name="my_name", unique=True)
+        )
+        keys = [k for k, _ in idx._canonical_options]
+        assert "name" not in keys
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: index creation with real MongoDB
+# ---------------------------------------------------------------------------
+
+
+async def test_simple_index_creation():
+    collection = DocumentTestModelWithSimpleIndex.get_pymongo_collection()
+    index_info = await collection.index_information()
+    assert index_info["test_int_1"] == {"key": [("test_int", 1)], "v": 2}
+    assert index_info["test_str_text"]["key"] == [
+        ("_fts", "text"),
+        ("_ftsx", 1),
+    ]
+
+
+async def test_flagged_index_creation():
+    collection = DocumentTestModelWithIndexFlags.get_pymongo_collection()
+    index_info = await collection.index_information()
+    assert index_info["test_int_1"] == {
+        "key": [("test_int", 1)],
+        "sparse": True,
+        "v": 2,
+    }
+    assert index_info["test_str_-1"] == {
+        "key": [("test_str", -1)],
+        "unique": True,
+        "v": 2,
+    }
+
+
+async def test_flagged_index_creation_with_alias():
+    collection = (
+        DocumentTestModelWithIndexFlagsAliases.get_pymongo_collection()
+    )
+    index_info = await collection.index_information()
+    assert index_info["testInt_1"] == {
+        "key": [("testInt", 1)],
+        "sparse": True,
+        "v": 2,
+    }
+    assert index_info["testStr_-1"] == {
+        "key": [("testStr", -1)],
+        "unique": True,
+        "v": 2,
+    }
+
+
+async def test_annotated_index_creation():
+    collection = DocumentTestModelIndexFlagsAnnotated.get_pymongo_collection()
+    index_info = await collection.index_information()
+    assert index_info["str_index_text"]["key"] == [
+        ("_fts", "text"),
+        ("_ftsx", 1),
+    ]
+    assert index_info["str_index_annotated_1"] == {
+        "key": [("str_index_annotated", 1)],
+        "v": 2,
+    }
+    assert index_info["uuid_index_annotated_1"] == {
+        "key": [("uuid_index_annotated", 1)],
+        "unique": True,
+        "v": 2,
+    }
+    if "uuid_index" in index_info:
+        assert index_info["uuid_index"] == {
+            "key": [("uuid_index", 1)],
+            "unique": True,
+            "v": 2,
+        }
+
+
+async def test_complex_index_creation():
+    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
+    index_info = await collection.index_information()
+    assert index_info == {
+        "_id_": {"key": [("_id", 1)], "v": 2},
+        "test_int_1": {"key": [("test_int", 1)], "v": 2},
+        "test_int_1_test_str_-1": {
+            "key": [("test_int", 1), ("test_str", -1)],
+            "v": 2,
+        },
+        "test_string_index_DESCENDING": {"key": [("test_str", -1)], "v": 2},
+    }
+
+
+async def test_index_recreation(settings):
+    class Sample1(Document):
+        name: Indexed(str, unique=True)
+
+        class Settings:
+            name = "sample"
+
+    class Sample2(Document):
+        name: str
+        status: str = "active"
+
+        class Settings:
+            indexes = [
+                IndexModel(
+                    "name",
+                    unique=True,
+                    partialFilterExpression={"is_active": {"$eq": "active"}},
+                ),
+            ]
+            name = "sample"
+
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await db.drop_collection("sample")
+
+        await init_beanie(database=db, document_models=[Sample1])
+        await init_beanie(
+            database=db, document_models=[Sample2], allow_index_dropping=True
+        )
+
+        await db.drop_collection("sample")
+
+
+async def test_index_on_custom_types(settings):
+    class Sample1(Document):
+        name: Indexed(Color, unique=True)
+
+        class Settings:
+            name = "sample"
+
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await db.drop_collection("sample")
+        await init_beanie(database=db, document_models=[Sample1])
+        await db.drop_collection("sample")
+
+
+async def test_merge_indexes():
+    """Backward compat: inheritance-based merge still works correctly."""
+    collection = DocumentWithIndexMerging2.get_pymongo_collection()
+    index_info = await collection.index_information()
+    assert index_info == {
+        "_id_": {"key": [("_id", 1)], "v": 2},
+        "s0_1": {"key": [("s0", 1)], "v": 2},
+        "s1_1": {"key": [("s1", 1)], "v": 2},
+        "s2_-1": {"key": [("s2", -1)], "v": 2},
+        "s3_index": {"key": [("s3", -1)], "v": 2},
+        "s4_index": {"key": [("s4", 1)], "v": 2},
+    }
+
+
+async def test_merge_multiple_indexes_same_field_same_options(settings):
+    """Identical indexes on same field collapse to one."""
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await init_beanie(
+            database=db,
+            document_models=[
+                DocumentWithMultipleIndexesOnSameFieldWithSameOptions
+            ],
+        )
+
+        collection = DocumentWithMultipleIndexesOnSameFieldWithSameOptions.get_pymongo_collection()
+        index_info = await collection.index_information()
+
+        assert json.loads(json.dumps(index_info)) == {
+            "_id_": {"v": 2, "key": [["_id", 1]]},
+            "status_1": {"v": 2, "key": [["status", 1]]},
+        }
+
+
+async def test_merge_multiple_indexes_same_field_different_name_same_options(
+    settings,
+):
+    """Same options but different explicit names → deduplicates (last wins)."""
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await init_beanie(
+            database=db,
+            document_models=[DocumentWithMultipleSameIndexesWithDifferentName],
+        )
+
+        collection = DocumentWithMultipleSameIndexesWithDifferentName.get_pymongo_collection()
+        index_info = await collection.index_information()
+
+        assert json.loads(json.dumps(index_info)) == {
+            "_id_": {"v": 2, "key": [["_id", 1]]},
+            "processing_expire_31": {
+                "v": 2,
+                "key": [["created_at", 1]],
+                "partialFilterExpression": {"status": "processing"},
+                "expireAfterSeconds": 30,
+            },
+        }
+
+
+async def test_merge_multiple_indexes_same_field_different_options(settings):
+    """Different options on same field → both indexes created (user's bug fix)."""
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await init_beanie(
+            database=db,
+            document_models=[DocumentWithMultipleIndexesOnSameField],
+        )
+
+        collection = (
+            DocumentWithMultipleIndexesOnSameField.get_pymongo_collection()
+        )
+        index_info = await collection.index_information()
+
+        assert json.loads(json.dumps(index_info)) == {
+            "_id_": {"v": 2, "key": [["_id", 1]]},
+            "status_-1": {"v": 2, "key": [["status", -1]]},
+            "processing_expire_30": {
+                "v": 2,
+                "key": [["created_at", 1]],
+                "partialFilterExpression": {"status": "processing"},
+                "expireAfterSeconds": 30,
+            },
+            "unpaid_expire_900": {
+                "v": 2,
+                "key": [["created_at", 1]],
+                "partialFilterExpression": {"status": "unpaid"},
+                "expireAfterSeconds": 900,
+            },
+        }
+
+
+async def test_merge_compound_indexes(settings):
+    """Compound indexes with different directions/options all preserved."""
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await init_beanie(
+            database=db, document_models=[DocumentWithCompoundIndexes]
+        )
+
+        collection = DocumentWithCompoundIndexes.get_pymongo_collection()
+        index_info = await collection.index_information()
+
+        assert json.loads(json.dumps(index_info)) == {
+            "_id_": {"v": 2, "key": [["_id", 1]]},
+            "field_a_1_field_b_1": {
+                "v": 2,
+                "key": [["field_a", 1], ["field_b", 1]],
+            },
+            "field_a_-1_field_b_-1": {
+                "v": 2,
+                "key": [["field_a", -1], ["field_b", -1]],
+            },
+            "compound_unique": {
+                "v": 2,
+                "key": [["field_a", 1], ["field_b", 1]],
+                "unique": True,
+            },
+            "ttl_index": {
+                "v": 2,
+                "key": [["created_at", 1]],
+                "expireAfterSeconds": 60,
+            },
+        }
+
+
+async def test_merge_compound_indexes_direction_conflict(settings):
+    """Compound indexes differing only in direction → both kept."""
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await init_beanie(
+            database=db,
+            document_models=[DocumentWithCompoundIndexesDirectionConflict],
+        )
+
+        collection = DocumentWithCompoundIndexesDirectionConflict.get_pymongo_collection()
+        index_info = await collection.index_information()
+
+        assert json.loads(json.dumps(index_info)) == {
+            "_id_": {"v": 2, "key": [["_id", 1]]},
+            "a_1_b_-1": {"v": 2, "key": [["a", 1], ["b", -1]]},
+            "a_-1_b_-1": {"v": 2, "key": [["a", -1], ["b", -1]]},
+        }
+
+
+async def test_merge_compound_indexes_field_order_conflict(settings):
+    """Compound indexes with same fields in different order → both kept."""
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await init_beanie(
+            database=db,
+            document_models=[DocumentWithCompoundIndexesFieldOrderConflict],
+        )
+
+        collection = DocumentWithCompoundIndexesFieldOrderConflict.get_pymongo_collection()
+        index_info = await collection.index_information()
+
+        assert json.loads(json.dumps(index_info)) == {
+            "_id_": {"v": 2, "key": [["_id", 1]]},
+            "a_1_b_1": {"v": 2, "key": [["a", 1], ["b", 1]]},
+            "b_1_a_1": {"v": 2, "key": [["b", 1], ["a", 1]]},
+        }
+
+
+async def test_merge_indexes_options_order_conflict(settings):
+    """Options in different order are canonicalized → deduplicates."""
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        await init_beanie(
+            database=db,
+            document_models=[
+                DocumentWithMultipleSameIndexesOptionOrderConflict
+            ],
+        )
+
+        collection = DocumentWithMultipleSameIndexesOptionOrderConflict.get_pymongo_collection()
+        index_info = await collection.index_information()
+
+        assert json.loads(json.dumps(index_info)) == {
+            "_id_": {"v": 2, "key": [["_id", 1]]},
+            "a_1": {"v": 2, "key": [["a", 1]], "unique": True, "sparse": True},
+        }

--- a/tests/odm/documents/test_init.py
+++ b/tests/odm/documents/test_init.py
@@ -1,26 +1,19 @@
 from importlib.metadata import version
 
 import pytest
-from pymongo import AsyncMongoClient, IndexModel
+from pymongo import AsyncMongoClient
 
-from beanie import Document, Indexed, init_beanie
+from beanie import Document, init_beanie
 from beanie import __version__ as beanie_version
 from beanie.exceptions import CollectionWasNotInitialized
-from beanie.odm.utils.projection import get_projection
 from tests.odm.models import (
     Color,
-    DocumentTestModel,
-    DocumentTestModelIndexFlagsAnnotated,
     DocumentTestModelStringImport,
     DocumentTestModelWithComplexIndex,
     DocumentTestModelWithCustomCollectionName,
     DocumentTestModelWithDroppedIndex,
-    DocumentTestModelWithIndexFlags,
-    DocumentTestModelWithIndexFlagsAliases,
-    DocumentTestModelWithSimpleIndex,
     DocumentToBeLinked,
     DocumentWithCustomInit,
-    DocumentWithIndexMerging2,
     DocumentWithLink,
     DocumentWithListLink,
     DocumentWithOptionalTypingOptionalBackLink,
@@ -30,12 +23,8 @@ from tests.odm.models import (
 )
 
 
-def test_init_collection_was_not_initialized():
-    class NewDocument(Document):
-        test_str: str
-
-    with pytest.raises(CollectionWasNotInitialized):
-        NewDocument(test_str="test")
+def test_custom_init():
+    assert DocumentWithCustomInit.s == "TEST2"
 
 
 async def test_init_connection_string(settings):
@@ -109,6 +98,48 @@ async def test_metadata_database(settings):
         assert beanie_version in metadata["driver"]["version"]
 
 
+async def test_init_document_models_string_import(settings):
+    async with AsyncMongoClient(settings.mongodb_dsn) as client:
+        db = client[settings.mongodb_db_name]
+        try:
+            await init_beanie(
+                database=db,
+                document_models=[
+                    "tests.odm.models.DocumentTestModelStringImport",
+                ],
+            )
+            document = DocumentTestModelStringImport(test_int=1)
+            assert document.id is None
+            await document.insert()
+            assert document.id is not None
+
+            with pytest.raises(ValueError):
+                await init_beanie(
+                    database=db,
+                    document_models=[
+                        "tests",
+                    ],
+                )
+
+            with pytest.raises(AttributeError):
+                await init_beanie(
+                    database=db,
+                    document_models=[
+                        "tests.wrong",
+                    ],
+                )
+        finally:
+            await DocumentTestModelStringImport.get_pymongo_collection().drop()
+
+
+def test_init_collection_was_not_initialized():
+    class NewDocument(Document):
+        test_str: str
+
+    with pytest.raises(CollectionWasNotInitialized):
+        NewDocument(test_str="test")
+
+
 def test_collection_with_custom_name():
     collection = (
         DocumentTestModelWithCustomCollectionName.get_pymongo_collection()
@@ -116,265 +147,25 @@ def test_collection_with_custom_name():
     assert collection.name == "custom"
 
 
-async def test_simple_index_creation():
-    collection = DocumentTestModelWithSimpleIndex.get_pymongo_collection()
-    index_info = await collection.index_information()
-    assert index_info["test_int_1"] == {"key": [("test_int", 1)], "v": 2}
-    assert index_info["test_str_text"]["key"] == [
-        ("_fts", "text"),
-        ("_ftsx", 1),
-    ]
-
-
-async def test_flagged_index_creation():
-    collection = DocumentTestModelWithIndexFlags.get_pymongo_collection()
-    index_info = await collection.index_information()
-    assert index_info["test_int_1"] == {
-        "key": [("test_int", 1)],
-        "sparse": True,
-        "v": 2,
-    }
-    assert index_info["test_str_-1"] == {
-        "key": [("test_str", -1)],
-        "unique": True,
-        "v": 2,
-    }
-
-
-async def test_flagged_index_creation_with_alias():
-    collection = (
-        DocumentTestModelWithIndexFlagsAliases.get_pymongo_collection()
-    )
-    index_info = await collection.index_information()
-    assert index_info["testInt_1"] == {
-        "key": [("testInt", 1)],
-        "sparse": True,
-        "v": 2,
-    }
-    assert index_info["testStr_-1"] == {
-        "key": [("testStr", -1)],
-        "unique": True,
-        "v": 2,
-    }
-
-
-async def test_annotated_index_creation():
-    collection = DocumentTestModelIndexFlagsAnnotated.get_pymongo_collection()
-    index_info = await collection.index_information()
-    assert index_info["str_index_text"]["key"] == [
-        ("_fts", "text"),
-        ("_ftsx", 1),
-    ]
-    assert index_info["str_index_annotated_1"] == {
-        "key": [("str_index_annotated", 1)],
-        "v": 2,
-    }
-
-    assert index_info["uuid_index_annotated_1"] == {
-        "key": [("uuid_index_annotated", 1)],
-        "unique": True,
-        "v": 2,
-    }
-    if "uuid_index" in index_info:
-        assert index_info["uuid_index"] == {
-            "key": [("uuid_index", 1)],
-            "unique": True,
-            "v": 2,
-        }
-
-
-async def test_complex_index_creation():
-    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
-    index_info = await collection.index_information()
-    assert index_info == {
-        "_id_": {"key": [("_id", 1)], "v": 2},
-        "test_int_1": {"key": [("test_int", 1)], "v": 2},
-        "test_int_1_test_str_-1": {
-            "key": [("test_int", 1), ("test_str", -1)],
-            "v": 2,
-        },
-        "test_string_index_DESCENDING": {"key": [("test_str", -1)], "v": 2},
-    }
-
-
-async def test_index_dropping_is_allowed(db):
-    await init_beanie(
-        database=db, document_models=[DocumentTestModelWithComplexIndex]
-    )
-    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
-
-    await init_beanie(
-        database=db,
-        document_models=[DocumentTestModelWithDroppedIndex],
-        allow_index_dropping=True,
-    )
-
-    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
-    index_info = await collection.index_information()
-    assert index_info == {
-        "_id_": {"key": [("_id", 1)], "v": 2},
-        "test_int_1": {"key": [("test_int", 1)], "v": 2},
-    }
-
-
-async def test_index_dropping_is_not_allowed(db):
-    await init_beanie(
-        database=db, document_models=[DocumentTestModelWithComplexIndex]
-    )
-    await init_beanie(
-        database=db,
-        document_models=[DocumentTestModelWithDroppedIndex],
-        allow_index_dropping=False,
-    )
-
-    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
-    index_info = await collection.index_information()
-    assert index_info == {
-        "_id_": {"key": [("_id", 1)], "v": 2},
-        "test_int_1": {"key": [("test_int", 1)], "v": 2},
-        "test_int_1_test_str_-1": {
-            "key": [("test_int", 1), ("test_str", -1)],
-            "v": 2,
-        },
-        "test_string_index_DESCENDING": {"key": [("test_str", -1)], "v": 2},
-    }
-
-
-async def test_index_dropping_is_not_allowed_as_default(db):
-    await init_beanie(
-        database=db, document_models=[DocumentTestModelWithComplexIndex]
-    )
-    await init_beanie(
-        database=db,
-        document_models=[DocumentTestModelWithDroppedIndex],
-    )
-
-    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
-    index_info = await collection.index_information()
-    assert index_info == {
-        "_id_": {"key": [("_id", 1)], "v": 2},
-        "test_int_1": {"key": [("test_int", 1)], "v": 2},
-        "test_int_1_test_str_-1": {
-            "key": [("test_int", 1), ("test_str", -1)],
-            "v": 2,
-        },
-        "test_string_index_DESCENDING": {"key": [("test_str", -1)], "v": 2},
-    }
-
-
-async def test_document_string_import(db):
-    await init_beanie(
-        database=db,
-        document_models=[
-            "tests.odm.models.DocumentTestModelStringImport",
-        ],
-    )
-    document = DocumentTestModelStringImport(test_int=1)
-    assert document.id is None
-    await document.insert()
-    assert document.id is not None
-
-    with pytest.raises(ValueError):
-        await init_beanie(
-            database=db,
-            document_models=[
-                "tests",
-            ],
-        )
-
-    with pytest.raises(AttributeError):
-        await init_beanie(
-            database=db,
-            document_models=[
-                "tests.wrong",
-            ],
-        )
-
-
-def test_projection():
-    projection = get_projection(DocumentTestModel)
-    assert projection == {
-        "_id": 1,
-        "test_int": 1,
-        "test_list": 1,
-        "test_str": 1,
-        "test_doc": 1,
-        "revision_id": 1,
-    }
-
-
-async def test_index_recreation(settings):
+async def test_init_document_can_inherit_and_extend_settings(settings):
     class Sample1(Document):
-        name: Indexed(str, unique=True)
-
         class Settings:
-            name = "sample"
+            name = "sample1"
+            bson_encoders = {Color: lambda x: x.value}
 
-    class Sample2(Document):
-        name: str
-        status: str = "active"
-
-        class Settings:
-            indexes = [
-                IndexModel(
-                    "name",
-                    unique=True,
-                    partialFilterExpression={"is_active": {"$eq": "active"}},
-                ),
-            ]
-            name = "sample"
+    class Sample2(Sample1):
+        class Settings(Sample1.Settings):
+            name = "sample2"
 
     async with AsyncMongoClient(settings.mongodb_dsn) as client:
         db = client[settings.mongodb_db_name]
-        await db.drop_collection("sample")
-
         await init_beanie(
             database=db,
-            document_models=[Sample1],
+            document_models=[Sample2],
         )
 
-        await init_beanie(
-            database=db, document_models=[Sample2], allow_index_dropping=True
-        )
-
-        await db.drop_collection("sample")
-
-
-async def test_merge_indexes():
-    assert (
-        await DocumentWithIndexMerging2.get_pymongo_collection().index_information()
-        == {
-            "_id_": {"key": [("_id", 1)], "v": 2},
-            "s0_1": {"key": [("s0", 1)], "v": 2},
-            "s1_1": {"key": [("s1", 1)], "v": 2},
-            "s2_-1": {"key": [("s2", -1)], "v": 2},
-            "s3_index": {"key": [("s3", -1)], "v": 2},
-            "s4_index": {"key": [("s4", 1)], "v": 2},
-        }
-    )
-
-
-def test_custom_init():
-    assert DocumentWithCustomInit.s == "TEST2"
-
-
-async def test_index_on_custom_types(settings):
-    class Sample1(Document):
-        name: Indexed(Color, unique=True)
-
-        class Settings:
-            name = "sample"
-
-    async with AsyncMongoClient(settings.mongodb_dsn) as client:
-        db = client[settings.mongodb_db_name]
-        await db.drop_collection("sample")
-
-        await init_beanie(
-            database=db,
-            document_models=[Sample1],
-        )
-
-        await db.drop_collection("sample")
+        assert Sample2.get_settings().bson_encoders != {}
+        assert Sample2.get_settings().name == "sample2"
 
 
 async def test_init_document_with_union_type_expression_optional_link(db):
@@ -442,25 +233,51 @@ async def test_init_document_with_typing_optional_back_link(db):
     )
 
 
-async def test_init_document_can_inherit_and_extend_settings(settings):
-    class Sample1(Document):
-        class Settings:
-            name = "sample1"
-            bson_encoders = {Color: lambda x: x.value}
+async def test_init_allow_index_dropping_is_enabled(db):
+    await init_beanie(
+        database=db, document_models=[DocumentTestModelWithComplexIndex]
+    )
+    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
 
-    class Sample2(Sample1):
-        class Settings(Sample1.Settings):
-            name = "sample2"
+    await init_beanie(
+        database=db,
+        document_models=[DocumentTestModelWithDroppedIndex],
+        allow_index_dropping=True,
+    )
 
-    async with AsyncMongoClient(settings.mongodb_dsn) as client:
-        db = client[settings.mongodb_db_name]
-        await init_beanie(
-            database=db,
-            document_models=[Sample2],
-        )
+    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
+    index_info = await collection.index_information()
 
-        assert Sample2.get_settings().bson_encoders != {}
-        assert Sample2.get_settings().name == "sample2"
+    assert index_info == {
+        "_id_": {"key": [("_id", 1)], "v": 2},
+        "test_int_1": {"key": [("test_int", 1)], "v": 2},
+    }
+
+
+async def test_init_allow_index_dropping_is_disabled_by_default(db):
+    await init_beanie(
+        database=db, document_models=[DocumentTestModelWithComplexIndex]
+    )
+    await init_beanie(
+        database=db,
+        document_models=[DocumentTestModelWithDroppedIndex],
+    )
+
+    collection = DocumentTestModelWithComplexIndex.get_pymongo_collection()
+    index_info = await collection.index_information()
+
+    assert index_info == {
+        "_id_": {"key": [("_id", 1)], "v": 2},
+        "test_int_1": {"key": [("test_int", 1)], "v": 2},
+        "test_int_1_test_str_-1": {
+            "key": [("test_int", 1), ("test_str", -1)],
+            "v": 2,
+        },
+        "test_string_index_DESCENDING": {
+            "key": [("test_str", -1)],
+            "v": 2,
+        },
+    }
 
 
 async def test_init_beanie_with_skip_indexes(settings):
@@ -483,6 +300,6 @@ async def test_init_beanie_with_skip_indexes(settings):
 
         collection = NewDocument.get_pymongo_collection()
         index_info = await collection.index_information()
-        assert (
-            len(index_info) == 1
-        )  # Only the default _id index should be present
+
+        # Only the default _id index should be present
+        assert len(index_info) == 1

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -35,7 +35,6 @@ from pydantic import (
     validate_call,
 )
 from pydantic_core import core_schema
-from pymongo import IndexModel
 
 from beanie import (
     DecimalAnnotation,
@@ -210,7 +209,7 @@ class DocumentTestModelWithComplexIndex(Document):
                 ("test_int", pymongo.ASCENDING),
                 ("test_str", pymongo.DESCENDING),
             ],
-            IndexModel(
+            pymongo.IndexModel(
                 [("test_str", pymongo.DESCENDING)],
                 name="test_string_index_DESCENDING",
             ),
@@ -226,6 +225,142 @@ class DocumentTestModelWithDroppedIndex(Document):
         name = "docs_with_index"
         indexes = [
             "test_int",
+        ]
+
+
+class DocumentWithMultipleIndexesOnSameFieldWithSameOptions(Document):
+    status: str
+
+    class Settings:
+        merge_indexes = True
+        indexes = [
+            [
+                ("status", pymongo.ASCENDING),
+            ],
+            [
+                ("status", pymongo.ASCENDING),
+            ],
+            [
+                ("status", pymongo.ASCENDING),
+            ],
+        ]
+
+
+class DocumentWithMultipleIndexesOnSameField(Document):
+    created_at: Annotated[
+        datetime.datetime,
+        Field(default_factory=lambda: datetime.datetime.now(datetime.UTC)),
+    ]
+    status: Annotated[str, Indexed()]
+
+    class Settings:
+        merge_indexes = True
+        indexes = [
+            [
+                ("status", pymongo.DESCENDING),
+            ],
+            pymongo.IndexModel(
+                "created_at",
+                name="processing_expire_30",
+                expireAfterSeconds=30,
+                partialFilterExpression={"status": "processing"},
+            ),
+            pymongo.IndexModel(
+                "created_at",
+                name="unpaid_expire_900",
+                expireAfterSeconds=900,
+                partialFilterExpression={"status": "unpaid"},
+            ),
+        ]
+
+
+class DocumentWithMultipleSameIndexesWithDifferentName(Document):
+    created_at: Annotated[
+        datetime.datetime,
+        Field(default_factory=lambda: datetime.datetime.now(datetime.UTC)),
+    ]
+    status: str
+
+    class Settings:
+        merge_indexes = True
+        indexes = [
+            pymongo.IndexModel(
+                "created_at",
+                name="processing_expire_30",
+                expireAfterSeconds=30,
+                partialFilterExpression={"status": "processing"},
+            ),
+            pymongo.IndexModel(
+                "created_at",
+                name="processing_expire_31",
+                expireAfterSeconds=30,
+                partialFilterExpression={"status": "processing"},
+            ),
+        ]
+
+
+class DocumentWithMultipleSameIndexesOptionOrderConflict(Document):
+    a: Indexed(int, unique=True, sparse=True)
+
+    class Settings:
+        merge_indexes = True
+        # Explicitly add two indexes with identical keys but options in different order
+        indexes = [
+            pymongo.IndexModel([("a", 1)], unique=True, sparse=True),
+            pymongo.IndexModel([("a", 1)], sparse=True, unique=True),
+        ]
+
+
+class DocumentWithCompoundIndexes(Document):
+    field_a: int
+    field_b: int
+    created_at: Annotated[
+        datetime.datetime,
+        Field(default_factory=lambda: datetime.datetime.now(datetime.UTC)),
+    ]
+
+    class Settings:
+        merge_indexes = True
+        indexes = [
+            [("field_a", pymongo.ASCENDING), ("field_b", pymongo.ASCENDING)],
+            [("field_a", pymongo.DESCENDING), ("field_b", pymongo.DESCENDING)],
+            pymongo.IndexModel(
+                [
+                    ("field_a", pymongo.ASCENDING),
+                    ("field_b", pymongo.ASCENDING),
+                ],
+                unique=True,
+                name="compound_unique",
+            ),
+            pymongo.IndexModel(
+                [("created_at", pymongo.ASCENDING)],
+                expireAfterSeconds=60,
+                name="ttl_index",
+            ),
+        ]
+
+
+class DocumentWithCompoundIndexesDirectionConflict(Document):
+    a: int
+    b: int
+
+    class Settings:
+        merge_indexes = True
+        indexes = [
+            [("a", 1), ("b", -1)],
+            [("a", -1), ("b", -1)],
+        ]
+
+
+class DocumentWithCompoundIndexesFieldOrderConflict(Document):
+    a: int
+    b: int
+
+    class Settings:
+        merge_indexes = True
+        indexes = [
+            [("a", 1), ("b", 1)],
+            [("b", 1), ("a", 1)],
         ]
 
 
@@ -1084,11 +1219,11 @@ class DocumentWithIndexMerging1(Document):
             [
                 ("s2", pymongo.ASCENDING),
             ],
-            IndexModel(
+            pymongo.IndexModel(
                 [("s3", pymongo.ASCENDING)],
                 name="s3_index",
             ),
-            IndexModel(
+            pymongo.IndexModel(
                 [("s4", pymongo.ASCENDING)],
                 name="s4_index",
             ),
@@ -1104,7 +1239,7 @@ class DocumentWithIndexMerging2(DocumentWithIndexMerging1):
             [
                 ("s2", pymongo.DESCENDING),
             ],
-            IndexModel(
+            pymongo.IndexModel(
                 [("s3", pymongo.DESCENDING)],
                 name="s3_index",
             ),


### PR DESCRIPTION
I was trying to create two indexes on the same field for my model:

```python
class Order(OrderInit, Document):
    created_at: Annotated[
        AwareDatetime,
        Field(default_factory=lambda: datetime.now(UTC))
    ]
    status: Annotated[OrderStatus, Indexed()]

    class Settings:
        indexes = [
            IndexModel(
                "created_at", name="processing_expire_30", expireAfterSeconds=30, partialFilterExpression={"status": "processing"}
            ),
            IndexModel(
                "created_at", name="unpaid_expire_900", expireAfterSeconds=900, partialFilterExpression={"status": "unpaid"}
            )
        ]
```

However, the current implementation will overwrite the first index definition with the second one because they have the same dict key if the key is `index.fields`. I changed the key to `index.name` so by providing a different name than the default one, the indexes will no longer overwrite each others.

Also I was trying to make it work with `Annotated` too:

```python
class Order(OrderInit, Document):
    created_at: Annotated[
        AwareDatetime,
        Indexed(name="processing_expire_30", expireAfterSeconds=30, partialFilterExpression={"status": "processing"}),
        Indexed(name="unpaid_expire_900", expireAfterSeconds=900, partialFilterExpression={"status": "unpaid"}),
        Field(default_factory=lambda: datetime.now(UTC))
    ]
    status: Annotated[OrderStatus, Indexed()]
```

but it would change the return type of [`get_index_attributes()`](https://github.com/BeanieODM/beanie/blob/f19416dbfc1c539770dab095f05b2bc18cb73741/beanie/odm/utils/typing.py#L28) so I didn't go further.