### PR TITLE
fix: Pydantic "exclude" option is not working #756

### DIFF
--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -160,7 +160,11 @@ class Encoder:
             field_info = get_model_field(key)
             if field_info is not None:
                 key = field_info.alias or key
-            if key not in exclude and (value is not None or keep_nulls):
+            if (
+                key not in exclude
+                and (value is not None or keep_nulls)
+                and not (field_info is not None and field_info.exclude is True)
+            ):
                 yield key, value
 
 

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -163,7 +163,15 @@ class Encoder:
             if (
                 key not in exclude
                 and (value is not None or keep_nulls)
-                and not (field_info is not None and field_info.exclude is True)
+                and not (
+                    field_info is not None
+                    and (
+                        field_info.exclude
+                        if IS_PYDANTIC_V2
+                        else getattr(field_info.field_info.exclude, "exclude")
+                    )
+                    is True
+                )
             ):
                 yield key, value
 

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -47,6 +47,7 @@ from tests.odm.models import (
     DocumentWithDecimalField,
     DocumentWithDeprecatedHiddenField,
     DocumentWithEnumKeysDict,
+    DocumentWithExcludedField,
     DocumentWithExtras,
     DocumentWithHttpUrlField,
     DocumentWithIndexedObjectId,
@@ -207,6 +208,7 @@ TESTING_MODELS = [
     LongSelfLink,
     BsonRegexDoc,
     NativeRegexDoc,
+    DocumentWithExcludedField,
 ]
 
 

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -165,7 +165,7 @@ class DocumentTestModel(Document):
     test_int: int
     test_doc: SubDocument
     test_str: str
-    test_list: List[SubDocument] = Field(exclude=True)
+    test_list: List[SubDocument]
 
     class Settings:
         use_cache = True
@@ -568,7 +568,7 @@ class House(Document):
     roof: Optional[Link[Roof]] = None
     yards: Optional[List[Link[Yard]]] = None
     height: Indexed(int) = 2
-    name: Indexed(str) = Field(exclude=True)
+    name: Indexed(str)
 
     if IS_PYDANTIC_V2:
         model_config = ConfigDict(

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -894,6 +894,11 @@ class DocumentWithKeepNullsFalse(Document):
         use_state_management = True
 
 
+class DocumentWithExcludedField(Document):
+    included_field: int
+    excluded_field: Optional[int] = Field(default=None, exclude=True)
+
+
 class ReleaseElemMatch(BaseModel):
     major_ver: int
     minor_ver: int

--- a/tests/odm/test_encoder.py
+++ b/tests/odm/test_encoder.py
@@ -18,6 +18,7 @@ from tests.odm.models import (
     DocumentWithComplexDictKey,
     DocumentWithDecimalField,
     DocumentWithEnumKeysDict,
+    DocumentWithExcludedField,
     DocumentWithHttpUrlField,
     DocumentWithKeepNullsFalse,
     DocumentWithStringField,
@@ -136,6 +137,21 @@ def test_keep_nulls_false():
     encoder = Encoder(keep_nulls=False, to_db=True)
     encoded_doc = encoder.encode(doc)
     assert encoded_doc == {"m": {"i": 10}}
+
+
+async def test_excluded_field():
+    assert isinstance(Encoder().encode(datetime.now()), datetime)
+
+    doc = DocumentWithExcludedField(included_field=1, excluded_field=2)
+    encoded_doc = Encoder().encode(doc)
+    assert "included_field" in encoded_doc
+    assert "excluded_field" not in encoded_doc
+
+    await doc.insert()
+    stored_doc = await DocumentWithExcludedField.get(doc.id)
+    assert stored_doc is not None
+    assert "included_field" in stored_doc.model_dump()
+    assert "excluded_field" not in stored_doc.model_dump()
 
 
 @pytest.mark.skipif(not IS_PYDANTIC_V2, reason="Test only for Pydantic v2")


### PR DESCRIPTION
This PR fixes an issue where Beanie document models did not respect the `exclude=True` option from Pydantic.  
Previously, even fields marked as excluded were being saved to the database.  
This behavior is now corrected.
A test case is also added.

Related issue: https://github.com/BeanieODM/beanie/issues/756