### PR TITLE
feat: support `@computed_field` of pydantic v2

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -341,6 +341,61 @@ class ExpressionField(str):
         return self
 
 
+class ExpressionFieldProperty(property):
+    def __init__(
+        self, original_property: property, expression_field: ExpressionField
+    ):
+        self._original = original_property
+        self._expression_field = expression_field
+        super().__init__(
+            original_property.fget,
+            original_property.fset,
+            original_property.fdel,
+            original_property.__doc__,
+        )
+
+    def __getitem__(self, item):
+        return ExpressionField(f"{self._expression_field}.{item}")
+
+    def __getattr__(self, item):
+        return ExpressionField(f"{self._expression_field}.{item}")
+
+    def __hash__(self):
+        return hash(str(self._expression_field))
+
+    def __eq__(self, other):
+        if isinstance(other, ExpressionField):
+            return super(ExpressionField, self._expression_field).__eq__(other)
+        return Eq(field=self._expression_field, other=other)
+
+    def __gt__(self, other):
+        return GT(field=self._expression_field, other=other)
+
+    def __ge__(self, other):
+        return GTE(field=self._expression_field, other=other)
+
+    def __lt__(self, other):
+        return LT(field=self._expression_field, other=other)
+
+    def __le__(self, other):
+        return LTE(field=self._expression_field, other=other)
+
+    def __ne__(self, other):
+        return NE(field=self._expression_field, other=other)
+
+    def __pos__(self):
+        return self._expression_field, SortDirection.ASCENDING
+
+    def __neg__(self):
+        return self._expression_field, SortDirection.DESCENDING
+
+    def __copy__(self):
+        return self._expression_field
+
+    def __deepcopy__(self, memo):
+        return self._expression_field
+
+
 class DeleteRules(str, Enum):
     DO_NOTHING = "DO_NOTHING"
     DELETE_LINKS = "DELETE_LINKS"

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -20,11 +20,13 @@ from typing import Any
 import bson
 import pydantic
 from pydantic import AnyUrl
+from pydantic.fields import ComputedFieldInfo, FieldInfo
 from pydantic_core import Url
 
 import beanie
 from beanie.odm.fields import Link, LinkTypes
 from beanie.odm.utils.pydantic import (
+    get_model_all_items,
     get_model_fields,
 )
 
@@ -148,7 +150,7 @@ class Encoder:
     ) -> Iterable[tuple[str, Any]]:
         keep_nulls = self.keep_nulls
         get_model_field = get_model_fields(obj).get
-        for key, value in obj.__iter__():
+        for key, value in get_model_all_items(obj).items():
             field_info = get_model_field(key)
             if field_info is not None:
                 key = field_info.alias or key
@@ -158,13 +160,15 @@ class Encoder:
                 yield key, value
 
     def _should_exclude_field(
-        self, key: str, field_info: pydantic.fields.FieldInfo | None
+        self,
+        key: str,
+        field_info: FieldInfo | ComputedFieldInfo | None,
     ):
         if key in self.include:
             return False
 
         is_pydantic_excluded_field = (
-            field_info is not None and field_info.exclude is True
+            isinstance(field_info, FieldInfo) and field_info.exclude is True
         )
         return key in self.exclude or is_pydantic_excluded_field
 

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -23,6 +23,7 @@ from beanie.odm.documents import DocType, Document
 from beanie.odm.fields import (
     BackLink,
     ExpressionField,
+    ExpressionFieldProperty,
     Link,
     LinkInfo,
     LinkTypes,
@@ -35,6 +36,7 @@ from beanie.odm.settings.view import ViewSettings
 from beanie.odm.union_doc import UnionDoc, UnionDocType
 from beanie.odm.utils.pydantic import (
     get_extra_field_info,
+    get_field_type,
     get_model_fields,
     parse_model,
 )
@@ -211,9 +213,9 @@ class Initializer:
         :param field: ModelField
         :return: Optional[LinkInfo]
         """
-
-        origin = get_origin(field.annotation)
-        args = get_args(field.annotation)
+        annotation = get_field_type(field)
+        origin = get_origin(annotation)
+        args = get_args(annotation)
         classes = [
             Link,
             BackLink,
@@ -221,7 +223,7 @@ class Initializer:
 
         for cls in classes:
             # Check if annotation is one of the custom classes
-            if get_origin(field.annotation) is cls:
+            if get_origin(annotation) is cls:
                 if cls is Link:
                     return LinkInfo(
                         field_name=field_name,
@@ -268,7 +270,7 @@ class Initializer:
 
             # Check if annotation is Optional[custom class] or Optional[List[custom class]]
             elif (
-                (origin is Union or isinstance(field.annotation, UnionType))
+                (origin is Union or isinstance(annotation, UnionType))
                 and len(args) == 2
                 and type(None) in args
             ):
@@ -382,9 +384,18 @@ class Initializer:
             cls._link_fields = {}
         for k, v in get_model_fields(cls).items():
             path = v.alias or k
+            attr = getattr(cls, k, None)
             annotation = getattr(v, "annotation", None)
             resolution = ExpressionField._resolve_field(annotation)
-            setattr(cls, k, ExpressionField(path, field_resolution=resolution))
+            expression_field = ExpressionField(
+                path, field_resolution=resolution
+            )
+            if isinstance(attr, property):
+                setattr(
+                    cls, k, ExpressionFieldProperty(attr, expression_field)
+                )
+            else:
+                setattr(cls, k, expression_field)
 
             link_info = self.detect_link(v, k)
             depth_level = cls.get_settings().max_nesting_depths_per_field.get(

--- a/beanie/odm/utils/pydantic.py
+++ b/beanie/odm/utils/pydantic.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pydantic import BaseModel, TypeAdapter
+from pydantic.fields import ComputedFieldInfo
 
 
 def parse_object_as(object_type: type, data: Any):
@@ -8,13 +9,28 @@ def parse_object_as(object_type: type, data: Any):
 
 
 def get_field_type(field):
-    return field.annotation
+    if isinstance(field, ComputedFieldInfo):
+        return field.return_type
+    else:
+        return field.annotation
 
 
 def get_model_fields(model):
     if not isinstance(model, type):
         model = model.__class__
-    return model.model_fields
+    return {**model.model_fields, **model.model_computed_fields}
+
+
+def get_model_all_items(model):
+    return {
+        **dict(model.__iter__()),
+        **{
+            key: getattr(model, key)
+            for key in {
+                **model.__class__.model_computed_fields,
+            }.keys()
+        },
+    }
 
 
 def parse_model(model_type: type[BaseModel], data: Any):

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -47,6 +47,7 @@ from tests.odm.models import (
     DocumentWithBsonBinaryField,
     DocumentWithBsonEncodersFiledsTypes,
     DocumentWithComplexDictKey,
+    DocumentWithComputedField,
     DocumentWithCustomFiledsTypes,
     DocumentWithCustomIdInt,
     DocumentWithCustomIdUUID,
@@ -242,6 +243,7 @@ TESTING_MODELS = [
     DocumentWithNestedAlias,
     DocumentWithDeepNestedAlias,
     DocumentWithAliasedLink,
+    DocumentWithComputedField,
 ]
 
 TESTING_MODELS.append(DocumentWithCustomIterRootModel)

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -32,6 +32,7 @@ from pydantic import (
     RootModel,
     SecretBytes,
     SecretStr,
+    computed_field,
     validate_call,
 )
 from pydantic_core import core_schema
@@ -967,6 +968,28 @@ class DocumentWithFrozenField(Document):
 
     class Settings:
         name = "docs_with_frozen_field"
+
+
+class DocumentWithComputedField(Document):
+    num: int
+
+    _cached_uuid: str | None = None
+
+    @computed_field
+    @property
+    def doubled(self) -> int:
+        return self.num * 2
+
+    @computed_field
+    @property
+    def cacheable_uuid(self) -> str:
+        if self._cached_uuid is None:
+            self._cached_uuid = str(uuid4())
+        return self._cached_uuid
+
+    @cacheable_uuid.setter
+    def cacheable_uuid(self, new: str) -> None:
+        self._cached_uuid = new
 
 
 class ReleaseElemMatch(BaseModel):

--- a/tests/odm/test_encoder.py
+++ b/tests/odm/test_encoder.py
@@ -14,6 +14,7 @@ from tests.odm.models import (
     DocumentForEncodingTest,
     DocumentForEncodingTestDate,
     DocumentWithComplexDictKey,
+    DocumentWithComputedField,
     DocumentWithDecimalField,
     DocumentWithEnumKeysDict,
     DocumentWithExcludedField,
@@ -142,6 +143,12 @@ def test_excluded():
     encoded_doc = Encoder().encode(doc)
     assert "included_field" in encoded_doc
     assert "excluded_field" not in encoded_doc
+
+
+def test_computed_field():
+    doc = DocumentWithComputedField(num=1)
+    encoded_doc = Encoder().encode(doc)
+    assert encoded_doc["doubled"] == 2
 
 
 def test_should_encode_pydantic_v2_url_correctly():

--- a/tests/odm/test_fields.py
+++ b/tests/odm/test_fields.py
@@ -16,6 +16,7 @@ from tests.odm.models import (
     DocumentTestModel,
     DocumentTestModelIndexFlagsAnnotated,
     DocumentWithBsonEncodersFiledsTypes,
+    DocumentWithComputedField,
     DocumentWithCustomFiledsTypes,
     DocumentWithDeprecatedHiddenField,
     DocumentWithExcludedField,
@@ -117,6 +118,45 @@ async def test_excluded(document):
     assert stored_doc is not None
     assert "included_field" in stored_doc.model_dump()
     assert "excluded_field" not in stored_doc.model_dump()
+
+
+async def test_computed_field():
+    doc = DocumentWithComputedField(num=1)
+    assert doc.doubled == 2
+
+    await doc.insert()
+    stored_doc = await DocumentWithComputedField.get(doc.id)
+    assert stored_doc
+    assert stored_doc.doubled == 2
+
+    stored_doc.num = 2
+    assert stored_doc.doubled == 4
+
+    await stored_doc.replace()
+    replaced_doc = await DocumentWithComputedField.get(doc.id)
+    assert replaced_doc
+    assert replaced_doc.doubled == 4
+
+
+async def test_computed_field_setter():
+    doc = DocumentWithComputedField(num=1)
+    await doc.insert()
+    cached_uui = doc.cacheable_uuid
+    db_raw_data = (
+        await DocumentWithComputedField.get_pymongo_collection().find_one(
+            {"_id": doc.id}
+        )
+    )
+    assert db_raw_data == {
+        "_id": doc.id,
+        "num": 1,
+        "doubled": 2,
+        "cacheable_uuid": cached_uui,
+    }
+
+    fetched_doc = await DocumentWithComputedField.get(doc.id)
+    assert fetched_doc
+    assert fetched_doc.cacheable_uuid != cached_uui
 
 
 async def test_hidden(deprecated_init_beanie):


### PR DESCRIPTION
This PR adds support for `@computed_field` to Beanie, which is currently not supported.

reference:
- [model_fields](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_fields)
- [model_computed_fields](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_computed_fields)
