### PR TITLE
Transform AsyncDocMethod[DocType, P, R] into Any to fix "Incorrect call arguments" warning in PyCharm

### DIFF
--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -206,7 +206,7 @@ def after_event(
 
 def wrap_with_actions(
     event_type: EventTypes,
-) -> Callable[[AsyncDocMethod[DocType, P, R]], Any]:
+) -> Callable[["AsyncDocMethod[DocType, P, R]"], Any]:
     """
     Helper function to wrap Document methods with
     before and after event listeners

--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -206,9 +206,7 @@ def after_event(
 
 def wrap_with_actions(
     event_type: EventTypes,
-) -> Callable[
-    ["AsyncDocMethod[DocType, P, R]"], "AsyncDocMethod[DocType, P, R]"
-]:
+) -> Callable[[AsyncDocMethod[DocType, P, R]], Any]:
     """
     Helper function to wrap Document methods with
     before and after event listeners


### PR DESCRIPTION
As #1106 is still opened, creates much problems with projects and makes beanie almost unusable in PyCharm, and no other solutions satisfy both PyCharm type checker AND mypy type checker, replacement with "Any" looks like good idea