### PR TITLE
fix backlink serialization when link data is fetched

### DIFF
--- a/tests/fastapi/routes.py
+++ b/tests/fastapi/routes.py
@@ -71,3 +71,8 @@ async def create_house_new(house: House = Body(...)):
     await house.save(link_rule=WriteRules.WRITE)
     await house.sync()
     return house
+
+
+@house_router.get("/person/{id}", response_model=Person)
+async def get_person(id: PydanticObjectId):
+    return await Person.get(id, fetch_links=True, nesting_depth=1)

--- a/tests/fastapi/test_api.py
+++ b/tests/fastapi/test_api.py
@@ -66,3 +66,22 @@ async def test_create_house_new(api_client):
     assert resp_json["name"] == payload["name"]
     assert resp_json["owner"]["name"] == payload["owner"]["name"][-3:]
     assert resp_json["owner"]["house"]["collection"] == "House"
+
+
+async def test_get_person(api_client):
+    payload = {
+        "name": "FreshHouse",
+        "owner": {"name": "will_be_overridden_to_Bob"},
+    }
+    resp = await api_client.post("/v1/house", json=payload)
+    resp_json = resp.json()
+
+    person_id = resp_json["owner"].get("id")
+    if person_id is None:
+        person_id = resp_json["owner"].get("_id")
+    assert person_id is not None
+
+    resp2 = await api_client.get(f"/v1/person/{person_id}")
+
+    resp2_json = resp2.json()
+    assert resp2_json["name"] == payload["owner"]["name"][-3:]

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -613,6 +613,15 @@ class TestOther:
         )
 
         assert addresses_count[0] == {"count": 10}
+    
+    async def test_dump_model_with_fetched_backlink(self, link_and_backlink_doc_pair):
+        link_doc, back_link_doc = link_and_backlink_doc_pair
+
+        document_with_fetched_backlinks = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True, nesting_depth=1)
+        
+        assert document_with_fetched_backlinks is not None
+        document_with_fetched_backlinks.model_dump_json()
+            
 
     async def test_with_chaining_aggregation_and_text_search(self):
         # ARRANGE

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -613,15 +613,18 @@ class TestOther:
         )
 
         assert addresses_count[0] == {"count": 10}
-    
-    async def test_dump_model_with_fetched_backlink(self, link_and_backlink_doc_pair):
+
+    async def test_dump_model_with_fetched_backlink(
+        self, link_and_backlink_doc_pair
+    ):
         link_doc, back_link_doc = link_and_backlink_doc_pair
 
-        document_with_fetched_backlinks = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True, nesting_depth=1)
-        
+        document_with_fetched_backlinks = await DocumentWithBackLink.get(
+            back_link_doc.id, fetch_links=True, nesting_depth=1
+        )
+
         assert document_with_fetched_backlinks is not None
         document_with_fetched_backlinks.model_dump_json()
-            
 
     async def test_with_chaining_aggregation_and_text_search(self):
         # ARRANGE


### PR DESCRIPTION
Hello,

I have noticed in FastAPI, if using a model with a BackLink as the return type for a route, the data will fail validation due to an error in validating the BackLink field.

On further inspection, it seems that there was no serialization handling for the BackLink when the field contains valid data from the linked model. 

I took the similar approach from the Link field, using the `serialize` method. Find the Link implementation [here](https://github.com/BeanieODM/beanie/blob/ea651add303c2e512eab54590ca6ff3542d55cd7/beanie/odm/fields.py#L388)

Added a test that checks for this to the FastAPI tests.

Best,
Alex