### PR TITLE
ignore BackLink fields of the retrieved update result in merge_models function

### DIFF
--- a/beanie/odm/utils/parsing.py
+++ b/beanie/odm/utils/parsing.py
@@ -36,13 +36,13 @@ def merge_models(left: BaseModel, right: BaseModel) -> None:
         if isinstance(right_value, list):
             links_found = False
             for i in right_value:
-                if isinstance(i, (Link,BackLink)):
+                if isinstance(i, (Link, BackLink)):
                     links_found = True
                     break
             if links_found:
                 continue
             left.__setattr__(k, right_value)
-        elif not isinstance(right_value, (Link,BackLink)):
+        elif not isinstance(right_value, (Link, BackLink)):
             left.__setattr__(k, right_value)
 
 

--- a/beanie/odm/utils/parsing.py
+++ b/beanie/odm/utils/parsing.py
@@ -21,7 +21,7 @@ def merge_models(left: BaseModel, right: BaseModel) -> None:
     :param right: right model
     :return: None
     """
-    from beanie.odm.fields import Link
+    from beanie.odm.fields import BackLink, Link
 
     for k, right_value in right.__iter__():
         left_value = getattr(left, k)
@@ -36,13 +36,13 @@ def merge_models(left: BaseModel, right: BaseModel) -> None:
         if isinstance(right_value, list):
             links_found = False
             for i in right_value:
-                if isinstance(i, Link):
+                if isinstance(i, (Link,BackLink)):
                     links_found = True
                     break
             if links_found:
                 continue
             left.__setattr__(k, right_value)
-        elif not isinstance(right_value, Link):
+        elif not isinstance(right_value, (Link,BackLink)):
             left.__setattr__(k, right_value)
 
 


### PR DESCRIPTION
In the` merge_models` function, Link field of the right model is ignored while BackLink is not. This will cause inconsistency because  after you apply .save() method on a document with a prefetched link field the field is not changed, but for a document with a backlink field, it will be replaced with BackLink Ref not the real object.