### PR TITLE
chore: modernize Beanie codebase and types for py39+

### DIFF
--- a/.github/scripts/handlers/gh.py
+++ b/.github/scripts/handlers/gh.py
@@ -1,7 +1,6 @@
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
 
 import requests  # type: ignore
 
@@ -31,7 +30,7 @@ class GitHubHandler:
         self.commits = self.get_commits_after_tag(current_version)
         self.prs = [self.get_pr_for_commit(commit) for commit in self.commits]
 
-    def get_commits_after_tag(self, tag: str) -> List[str]:
+    def get_commits_after_tag(self, tag: str) -> list[str]:
         result = subprocess.run(
             ["git", "log", f"{tag}..HEAD", "--pretty=format:%H"],
             stdout=subprocess.PIPE,
@@ -64,9 +63,7 @@ class GitHubHandler:
         return markdown
 
     def commit_changes(self):
-        self.run_git_command(
-            ["git", "config", "--global", "user.name", "github-actions[bot]"]
-        )
+        self.run_git_command(["git", "config", "--global", "user.name", "github-actions[bot]"])
         self.run_git_command(
             [
                 "git",
@@ -77,9 +74,7 @@ class GitHubHandler:
             ]
         )
         self.run_git_command(["git", "add", "."])
-        self.run_git_command(
-            ["git", "commit", "-m", f"Bump version to {self.new_version}"]
-        )
+        self.run_git_command(["git", "commit", "-m", f"Bump version to {self.new_version}"])
         self.run_git_command(["git", "tag", self.new_version])
         self.git_push()
 
@@ -87,5 +82,5 @@ class GitHubHandler:
         self.run_git_command(["git", "push", "origin", "main", "--tags"])
 
     @staticmethod
-    def run_git_command(command: List[str]):
+    def run_git_command(command: list[str]):
         subprocess.run(command, check=True)

--- a/.github/scripts/handlers/version.py
+++ b/.github/scripts/handlers/version.py
@@ -31,9 +31,7 @@ class SemVer:
             (self.major > other.major)
             or (self.major == other.major and self.minor > other.minor)
             or (
-                self.major == other.major
-                and self.minor == other.minor
-                and self.patch > other.patch
+                self.major == other.major and self.minor == other.minor and self.patch > other.patch
             )
         )
 
@@ -47,9 +45,7 @@ class VersionHandler:
         self.init_py = self.ROOT_PATH / "beanie" / "__init__.py"
         self.changelog = self.ROOT_PATH / "docs" / "changelog.md"
 
-        self.current_version = self.parse_version_from_pyproject(
-            self.pyproject
-        )
+        self.current_version = self.parse_version_from_pyproject(self.pyproject)
         self.pypi_version = self.get_version_from_pypi()
 
         if self.current_version < self.pypi_version:
@@ -68,9 +64,7 @@ class VersionHandler:
         return SemVer(toml_data["project"]["version"])
 
     def get_version_from_pypi(self) -> SemVer:
-        response = requests.get(
-            f"https://pypi.org/pypi/{self.PACKAGE_NAME}/json"
-        )
+        response = requests.get(f"https://pypi.org/pypi/{self.PACKAGE_NAME}/json")
         if response.status_code == 200:
             return SemVer(response.json()["info"]["version"])
         raise ValueError("Can't get version from pypi")
@@ -90,9 +84,7 @@ class VersionHandler:
     def update_file_versions(self, files_to_update):
         for file_path in files_to_update:
             content = file_path.read_text()
-            content = content.replace(
-                str(self.pypi_version), str(self.current_version)
-            )
+            content = content.replace(str(self.pypi_version), str(self.current_version))
             file_path.write_text(content)
 
     def update_changelog(self):

--- a/beanie/executors/migrate.py
+++ b/beanie/executors/migrate.py
@@ -48,9 +48,7 @@ class MigrationSettings:
             or self.get_from_toml("database_name")
         )
         self.path = Path(
-            kwargs.get("path")
-            or self.get_env_value("path")
-            or self.get_from_toml("path")
+            kwargs.get("path") or self.get_env_value("path") or self.get_from_toml("path")
         )
         self.allow_index_dropping = bool(
             kwargs.get("allow_index_dropping")
@@ -85,9 +83,9 @@ class MigrationSettings:
                 or os.environ.get("beanie_database_name")
             )
         else:
-            value = os.environ.get(
-                f"BEANIE_{field_name.upper()}"
-            ) or os.environ.get(f"beanie_{field_name.lower()}")
+            value = os.environ.get(f"BEANIE_{field_name.upper()}") or os.environ.get(
+                f"beanie_{field_name.lower()}"
+            )
         return value
 
     @staticmethod
@@ -96,11 +94,7 @@ class MigrationSettings:
         if path.is_file():
             with path.open("rb") as f:
                 toml_data = tomllib.load(f)
-            val = (
-                toml_data.get("tool", {})
-                .get("beanie", {})
-                .get("migrations", {})
-            )
+            val = toml_data.get("tool", {}).get("beanie", {}).get("migrations", {})
         else:
             val = {}
         return val.get(field_name)
@@ -114,9 +108,7 @@ def migrations():
 async def run_migrate(settings: MigrationSettings):
     DBHandler.set_db(settings.connection_uri, settings.database_name)
     root = await MigrationNode.build(settings.path)
-    mode = RunningMode(
-        direction=settings.direction, distance=settings.distance
-    )
+    mode = RunningMode(direction=settings.direction, distance=settings.distance)
     await root.run(
         mode=mode,
         allow_index_dropping=settings.allow_index_dropping,
@@ -158,9 +150,7 @@ async def run_migrate(settings: MigrationSettings):
     type=str,
     help="MongoDB connection URI",
 )
-@click.option(
-    "-db", "--database_name", required=False, type=str, help="DataBase name"
-)
+@click.option("-db", "--database_name", required=False, type=str, help="DataBase name")
 @click.option(
     "-p",
     "--path",

--- a/beanie/migrations/controllers/base.py
+++ b/beanie/migrations/controllers/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import List, Type
 
 from beanie.odm.documents import Document
 
@@ -14,5 +13,5 @@ class BaseMigrationController(ABC):
 
     @property
     @abstractmethod
-    def models(self) -> List[Type[Document]]:
+    def models(self) -> list[type[Document]]:
         pass

--- a/beanie/migrations/controllers/free_fall.py
+++ b/beanie/migrations/controllers/free_fall.py
@@ -1,11 +1,11 @@
 from inspect import signature
-from typing import Any, List, Type
+from typing import Any
 
 from beanie.migrations.controllers.base import BaseMigrationController
 from beanie.odm.documents import Document
 
 
-def free_fall_migration(document_models: List[Type[Document]]):
+def free_fall_migration(document_models: list[type[Document]]):
     class FreeFallMigrationController(BaseMigrationController):
         def __init__(self, function):
             self.function = function
@@ -16,7 +16,7 @@ def free_fall_migration(document_models: List[Type[Document]]):
             pass
 
         @property
-        def models(self) -> List[Type[Document]]:
+        def models(self) -> list[type[Document]]:
             return self.document_models
 
         async def run(self, session):

--- a/beanie/migrations/models.py
+++ b/beanie/migrations/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import Field
 from pydantic.main import BaseModel
@@ -29,5 +29,5 @@ class RunningMode(BaseModel):
 
 class ParsedMigrations(BaseModel):
     path: str
-    names: List[str]
+    names: list[str]
     current: Optional[MigrationLog] = None

--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -6,11 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
     Optional,
-    Tuple,
-    Type,
     TypeVar,
     Union,
 )
@@ -53,21 +49,21 @@ After = ActionDirections.AFTER
 
 
 class ActionRegistry:
-    _actions: Dict[
-        Type["Document"],
-        Dict[EventTypes, Dict[ActionDirections, List[Callable[..., Any]]]],
+    _actions: dict[
+        type["Document"],
+        dict[EventTypes, dict[ActionDirections, list[Callable[..., Any]]]],
     ] = {}
 
     @classmethod
-    def clean_actions(cls, document_class: Type["Document"]):
+    def clean_actions(cls, document_class: type["Document"]):
         if cls._actions.get(document_class) is not None:
             del cls._actions[document_class]
 
     @classmethod
     def add_action(
         cls,
-        document_class: Type["Document"],
-        event_types: List[EventTypes],
+        document_class: type["Document"],
+        event_types: list[EventTypes],
         action_direction: ActionDirections,
         funct: Callable,
     ):
@@ -80,24 +76,19 @@ class ActionRegistry:
         """
         if cls._actions.get(document_class) is None:
             cls._actions[document_class] = {
-                action_type: {
-                    action_direction: []
-                    for action_direction in ActionDirections
-                }
+                action_type: {action_direction: [] for action_direction in ActionDirections}
                 for action_type in EventTypes
             }
         for event_type in event_types:
-            cls._actions[document_class][event_type][action_direction].append(
-                funct
-            )
+            cls._actions[document_class][event_type][action_direction].append(funct)
 
     @classmethod
     def get_action_list(
         cls,
-        document_class: Type["Document"],
+        document_class: type["Document"],
         event_type: EventTypes,
         action_direction: ActionDirections,
-    ) -> List[Callable]:
+    ) -> list[Callable]:
         """
         Get stored action list
         :param document_class: Type - document class
@@ -115,7 +106,7 @@ class ActionRegistry:
         instance: "Document",
         event_type: EventTypes,
         action_direction: ActionDirections,
-        exclude: List[Union[ActionDirections, str]],
+        exclude: list[Union[ActionDirections, str]],
     ):
         """
         Run actions
@@ -127,9 +118,7 @@ class ActionRegistry:
             return
 
         document_class = instance.__class__
-        actions_list = cls.get_action_list(
-            document_class, event_type, action_direction
-        )
+        actions_list = cls.get_action_list(document_class, event_type, action_direction)
         coros = []
         for action in actions_list:
             if action.__name__ in exclude:
@@ -147,7 +136,7 @@ F = TypeVar("F", bound=Any)
 
 
 def register_action(
-    event_types: Tuple[Union[List[EventTypes], EventTypes], ...],
+    event_types: tuple[Union[list[EventTypes], EventTypes], ...],
     action_direction: ActionDirections,
 ) -> Callable[[F], F]:
     """
@@ -174,7 +163,7 @@ def register_action(
 
 
 def before_event(
-    *args: Union[List[EventTypes], EventTypes],
+    *args: Union[list[EventTypes], EventTypes],
 ) -> Callable[[F], F]:
     """
     Decorator. It adds action, which should run before mentioned one
@@ -183,13 +172,11 @@ def before_event(
     :param args: Union[List[EventTypes], EventTypes] - event types
     :return: None
     """
-    return register_action(
-        action_direction=ActionDirections.BEFORE, event_types=args
-    )
+    return register_action(action_direction=ActionDirections.BEFORE, event_types=args)
 
 
 def after_event(
-    *args: Union[List[EventTypes], EventTypes],
+    *args: Union[list[EventTypes], EventTypes],
 ) -> Callable[[F], F]:
     """
     Decorator. It adds action, which should run after mentioned one
@@ -199,16 +186,12 @@ def after_event(
     :return: None
     """
 
-    return register_action(
-        action_direction=ActionDirections.AFTER, event_types=args
-    )
+    return register_action(action_direction=ActionDirections.AFTER, event_types=args)
 
 
 def wrap_with_actions(
     event_type: EventTypes,
-) -> Callable[
-    ["AsyncDocMethod[DocType, P, R]"], "AsyncDocMethod[DocType, P, R]"
-]:
+) -> Callable[["AsyncDocMethod[DocType, P, R]"], "AsyncDocMethod[DocType, P, R]"]:
     """
     Helper function to wrap Document methods with
     before and after event listeners
@@ -223,7 +206,7 @@ def wrap_with_actions(
         async def wrapper(  # type: ignore
             self: "DocType",
             *args: P.args,
-            skip_actions: Optional[List[Union[ActionDirections, str]]] = None,
+            skip_actions: Optional[list[Union[ActionDirections, str]]] = None,
             **kwargs: P.kwargs,
         ) -> R:
             if skip_actions is None:

--- a/beanie/odm/bulk.py
+++ b/beanie/odm/bulk.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
+from collections.abc import Mapping
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from pymongo import (
@@ -74,11 +73,11 @@ class BulkWriter:
         self,
         session: Optional[AsyncIOMotorClientSession] = None,
         ordered: bool = True,
-        object_class: Optional[Type[Union[Document, UnionDoc]]] = None,
+        object_class: Optional[type[Union["Document", "UnionDoc"]]] = None,
         bypass_document_validation: bool = False,
         comment: Optional[Any] = None,
     ) -> None:
-        self.operations: List[_WriteOp] = []
+        self.operations: list[_WriteOp] = []
         self.session = session
         self.ordered = ordered
         self.object_class = object_class
@@ -93,7 +92,7 @@ class BulkWriter:
 
     async def __aexit__(
         self,
-        exc_type: Optional[Type[BaseException]],
+        exc_type: Optional[type[BaseException]],
         exc: Optional[BaseException],
         tb: Optional[TracebackType],
     ) -> None:
@@ -130,7 +129,7 @@ class BulkWriter:
 
     def add_operation(
         self,
-        object_class: Type[Union[Document, UnionDoc]],
+        object_class: type[Union["Document", "UnionDoc"]],
         operation: _WriteOp,
     ):
         """
@@ -151,7 +150,5 @@ class BulkWriter:
             self._collection_name = object_class.get_collection_name()
         else:
             if object_class.get_collection_name() != self._collection_name:
-                raise ValueError(
-                    "All the operations should be for a same collection name"
-                )
+                raise ValueError("All the operations should be for a same collection name")
         self.operations.append(operation)

--- a/beanie/odm/cache.py
+++ b/beanie/odm/cache.py
@@ -22,10 +22,7 @@ class LRUCache:
     def get(self, key) -> Optional[CachedItem]:
         try:
             item: CachedItem = self.cache.pop(key)
-            if (
-                datetime.datetime.now(tz=timezone.utc) - item.timestamp
-                > self.expiration_time
-            ):
+            if datetime.datetime.now(tz=timezone.utc) - item.timestamp > self.expiration_time:
                 return None
             self.cache[key] = item
             return item.value

--- a/beanie/odm/custom_types/bson/binary.py
+++ b/beanie/odm/custom_types/bson/binary.py
@@ -1,8 +1,7 @@
-from typing import Any
+from typing import Annotated, Any
 
 import bson
 import pydantic
-from typing_extensions import Annotated
 
 from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
 
@@ -12,9 +11,7 @@ def _to_bson_binary(value: Any) -> bson.Binary:
 
 
 if IS_PYDANTIC_V2:
-    BsonBinary = Annotated[
-        bson.Binary, pydantic.PlainValidator(_to_bson_binary)
-    ]
+    BsonBinary = Annotated[bson.Binary, pydantic.PlainValidator(_to_bson_binary)]
 else:
 
     class BsonBinary(bson.Binary):  # type: ignore[no-redef]

--- a/beanie/odm/custom_types/decimal.py
+++ b/beanie/odm/custom_types/decimal.py
@@ -1,12 +1,10 @@
 import decimal
+from typing import Annotated
 
 import bson
 import pydantic
-from typing_extensions import Annotated
 
 DecimalAnnotation = Annotated[
     decimal.Decimal,
-    pydantic.BeforeValidator(
-        lambda v: v.to_decimal() if isinstance(v, bson.Decimal128) else v
-    ),
+    pydantic.BeforeValidator(lambda v: v.to_decimal() if isinstance(v, bson.Decimal128) else v),
 ]

--- a/beanie/odm/custom_types/re.py
+++ b/beanie/odm/custom_types/re.py
@@ -1,8 +1,8 @@
 import re
+from typing import Annotated
 
 import bson
 import pydantic
-from typing_extensions import Annotated
 
 from beanie.odm.utils.pydantic import IS_PYDANTIC_V2
 
@@ -14,9 +14,7 @@ def _to_bson_regex(v):
 if IS_PYDANTIC_V2:
     Pattern = Annotated[
         re.Pattern,
-        pydantic.BeforeValidator(
-            lambda v: v.try_compile() if isinstance(v, bson.Regex) else v
-        ),
+        pydantic.BeforeValidator(lambda v: v.try_compile() if isinstance(v, bson.Regex) else v),
     ]
 else:
 

--- a/beanie/odm/interfaces/aggregate.py
+++ b/beanie/odm/interfaces/aggregate.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Dict, Optional, Type, TypeVar, Union, overload
+from typing import Any, Optional, TypeVar, Union, overload
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from pydantic import BaseModel
@@ -20,20 +20,20 @@ class AggregateInterface:
     @overload
     @classmethod
     def aggregate(
-        cls: Type[DocType],
+        cls: type[DocType],
         aggregation_pipeline: list,
         projection_model: None = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         **pymongo_kwargs: Any,
-    ) -> AggregationQuery[Dict[str, Any]]: ...
+    ) -> AggregationQuery[dict[str, Any]]: ...
 
     @overload
     @classmethod
     def aggregate(
-        cls: Type[DocType],
+        cls: type[DocType],
         aggregation_pipeline: list,
-        projection_model: Type[DocumentProjectionType],
+        projection_model: type[DocumentProjectionType],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         **pymongo_kwargs: Any,
@@ -41,14 +41,14 @@ class AggregateInterface:
 
     @classmethod
     def aggregate(
-        cls: Type[DocType],
+        cls: type[DocType],
         aggregation_pipeline: list,
-        projection_model: Optional[Type[DocumentProjectionType]] = None,
+        projection_model: Optional[type[DocumentProjectionType]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         **pymongo_kwargs: Any,
     ) -> Union[
-        AggregationQuery[Dict[str, Any]],
+        AggregationQuery[dict[str, Any]],
         AggregationQuery[DocumentProjectionType],
     ]:
         """

--- a/beanie/odm/interfaces/aggregation_methods.py
+++ b/beanie/odm/interfaces/aggregation_methods.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
@@ -52,8 +52,8 @@ class AggregateMethods:
         ]
 
         # As we did not supply a projection we can safely cast the type (hinting to mypy that we know the type)
-        result: List[Dict[str, Any]] = cast(
-            List[Dict[str, Any]],
+        result: list[dict[str, Any]] = cast(
+            list[dict[str, Any]],
             await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
@@ -94,8 +94,8 @@ class AggregateMethods:
             {"$project": {"_id": 0, "avg": 1}},
         ]
 
-        result: List[Dict[str, Any]] = cast(
-            List[Dict[str, Any]],
+        result: list[dict[str, Any]] = cast(
+            list[dict[str, Any]],
             await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
@@ -135,8 +135,8 @@ class AggregateMethods:
             {"$project": {"_id": 0, "max": 1}},
         ]
 
-        result: List[Dict[str, Any]] = cast(
-            List[Dict[str, Any]],
+        result: list[dict[str, Any]] = cast(
+            list[dict[str, Any]],
             await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,
@@ -176,8 +176,8 @@ class AggregateMethods:
             {"$project": {"_id": 0, "min": 1}},
         ]
 
-        result: List[Dict[str, Any]] = cast(
-            List[Dict[str, Any]],
+        result: list[dict[str, Any]] = cast(
+            list[dict[str, Any]],
             await self.aggregate(
                 aggregation_pipeline=pipeline,
                 session=session,

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -1,15 +1,10 @@
 from abc import abstractmethod
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
-    Dict,
-    List,
-    Mapping,
     Optional,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     overload,
@@ -37,12 +32,12 @@ FindType = TypeVar("FindType", bound=Union["Document", "UnionDoc", "View"])
 class FindInterface:
     # Customization
     # Query builders could be replaced in the inherited classes
-    _find_one_query_class: ClassVar[Type] = FindOne
-    _find_many_query_class: ClassVar[Type] = FindMany
+    _find_one_query_class: ClassVar[type] = FindOne
+    _find_many_query_class: ClassVar[type] = FindMany
 
     _inheritance_inited: bool = False
     _class_id: ClassVar[Optional[str]]
-    _children: ClassVar[Dict[str, Type]]
+    _children: ClassVar[dict[str, type["Document"]]]
 
     @classmethod
     @abstractmethod
@@ -57,7 +52,7 @@ class FindInterface:
     @overload
     @classmethod
     def find_one(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
         projection_model: None = None,
         session: Optional[AsyncIOMotorClientSession] = None,
@@ -65,36 +60,36 @@ class FindInterface:
         fetch_links: bool = False,
         with_children: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindOne[FindType]: ...
 
     @overload
     @classmethod
     def find_one(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
-        projection_model: Type["DocumentProjectionType"],
+        projection_model: type["DocumentProjectionType"],
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindOne["DocumentProjectionType"]: ...
 
     @classmethod
     def find_one(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
-        projection_model: Optional[Type["DocumentProjectionType"]] = None,
+        projection_model: Optional[type["DocumentProjectionType"]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> Union[FindOne[FindType], FindOne["DocumentProjectionType"]]:
         """
@@ -124,56 +119,56 @@ class FindInterface:
     @overload
     @classmethod
     def find_many(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
         projection_model: None = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany[FindType]: ...
 
     @overload
     @classmethod
     def find_many(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
-        projection_model: Optional[Type["DocumentProjectionType"]] = None,
+        projection_model: Optional[type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany["DocumentProjectionType"]: ...
 
     @classmethod
     def find_many(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
-        projection_model: Optional[Type["DocumentProjectionType"]] = None,
+        projection_model: Optional[type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
@@ -210,56 +205,56 @@ class FindInterface:
     @overload
     @classmethod
     def find(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
         projection_model: None = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany[FindType]: ...
 
     @overload
     @classmethod
     def find(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
-        projection_model: Type["DocumentProjectionType"],
+        projection_model: type["DocumentProjectionType"],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany["DocumentProjectionType"]: ...
 
     @classmethod
     def find(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         *args: Union[Mapping[Any, Any], bool],
-        projection_model: Optional[Type["DocumentProjectionType"]] = None,
+        projection_model: Optional[type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
@@ -284,50 +279,50 @@ class FindInterface:
     @overload
     @classmethod
     def find_all(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         projection_model: None = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany[FindType]: ...
 
     @overload
     @classmethod
     def find_all(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
-        projection_model: Optional[Type["DocumentProjectionType"]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
+        projection_model: Optional[type["DocumentProjectionType"]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany["DocumentProjectionType"]: ...
 
     @classmethod
     def find_all(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
-        projection_model: Optional[Type["DocumentProjectionType"]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
+        projection_model: Optional[type["DocumentProjectionType"]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
@@ -359,50 +354,50 @@ class FindInterface:
     @overload
     @classmethod
     def all(  # type: ignore
-        cls: Type[FindType],
+        cls: type[FindType],
         projection_model: None = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany[FindType]: ...
 
     @overload
     @classmethod
     def all(  # type: ignore
-        cls: Type[FindType],
-        projection_model: Type["DocumentProjectionType"],
+        cls: type[FindType],
+        projection_model: type["DocumentProjectionType"],
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> FindMany["DocumentProjectionType"]: ...
 
     @classmethod
     def all(  # type: ignore
-        cls: Type[FindType],
-        projection_model: Optional[Type["DocumentProjectionType"]] = None,
+        cls: type[FindType],
+        projection_model: Optional[type["DocumentProjectionType"]] = None,
         skip: Optional[int] = None,
         limit: Optional[int] = None,
-        sort: Union[None, str, List[Tuple[str, SortDirection]]] = None,
+        sort: Union[None, str, list[tuple[str, SortDirection]]] = None,
         session: Optional[AsyncIOMotorClientSession] = None,
         ignore_cache: bool = False,
         with_children: bool = False,
         lazy_parse: bool = False,
         nesting_depth: Optional[int] = None,
-        nesting_depths_per_field: Optional[Dict[str, int]] = None,
+        nesting_depths_per_field: Optional[dict[str, int]] = None,
         **pymongo_kwargs: Any,
     ) -> Union[FindMany[FindType], FindMany["DocumentProjectionType"]]:
         """
@@ -433,37 +428,23 @@ class FindInterface:
         return await cls.find_all().count()  # type: ignore
 
     @classmethod
-    def _add_class_id_filter(cls, args: Tuple, with_children: bool = False):
+    def _add_class_id_filter(cls, args: tuple, with_children: bool = False):
         # skip if _class_id is already added
-        if any(
-            (
-                True
-                for a in args
-                if isinstance(a, Iterable) and cls.get_settings().class_id in a
-            )
-        ):
+        if any(True for a in args if isinstance(a, Iterable) and cls.get_settings().class_id in a):
             return args
 
-        if (
-            cls.get_model_type() == ModelType.Document
-            and cls._inheritance_inited
-        ):
+        if cls.get_model_type() == ModelType.Document and cls._inheritance_inited:
             if not with_children:
                 args += ({cls.get_settings().class_id: cls._class_id},)
             else:
                 args += (
                     {
                         cls.get_settings().class_id: {
-                            "$in": [cls._class_id]
-                            + [cname for cname in cls._children.keys()]
+                            "$in": [cls._class_id] + [cname for cname in cls._children.keys()]
                         }
                     },
                 )
 
         if cls.get_settings().union_doc:
-            args += (
-                {
-                    cls.get_settings().class_id: cls.get_settings().union_doc_alias
-                },
-            )
+            args += ({cls.get_settings().class_id: cls.get_settings().union_doc_alias},)
         return args

--- a/beanie/odm/interfaces/inheritance.py
+++ b/beanie/odm/interfaces/inheritance.py
@@ -1,19 +1,21 @@
 from typing import (
+    TYPE_CHECKING,
     ClassVar,
-    Dict,
     Optional,
-    Type,
 )
+
+if TYPE_CHECKING:
+    from beanie.odm.documents import Document
 
 
 class InheritanceInterface:
-    _children: ClassVar[Dict[str, Type]]
-    _parent: ClassVar[Optional[Type]]
+    _children: ClassVar[dict[str, type["Document"]]]
+    _parent: ClassVar[Optional["Document"]]
     _inheritance_inited: ClassVar[bool]
     _class_id: ClassVar[Optional[str]] = None
 
     @classmethod
-    def add_child(cls, name: str, clas: Type):
+    def add_child(cls, name: str, clas: type["Document"]) -> None:
         cls._children[name] = clas
         if cls._parent is not None:
             cls._parent.add_child(name, clas)

--- a/beanie/odm/interfaces/update.py
+++ b/beanie/odm/interfaces/update.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any, Optional, Union
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
@@ -30,7 +31,7 @@ class UpdateMethods:
 
     def set(
         self,
-        expression: Dict[Union[ExpressionField, str, Any], Any],
+        expression: dict[Union[ExpressionField, str, Any], Any],
         session: Optional[AsyncIOMotorClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **kwargs: Any,
@@ -57,13 +58,11 @@ class UpdateMethods:
         :param bulk_writer: Optional[BulkWriter] - bulk writer
         :return: self
         """
-        return self.update(
-            Set(expression), session=session, bulk_writer=bulk_writer, **kwargs
-        )
+        return self.update(Set(expression), session=session, bulk_writer=bulk_writer, **kwargs)
 
     def current_date(
         self,
-        expression: Dict[Union[datetime, ExpressionField, str], Any],
+        expression: dict[Union[datetime, ExpressionField, str], Any],
         session: Optional[AsyncIOMotorClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **kwargs: Any,
@@ -87,7 +86,7 @@ class UpdateMethods:
 
     def inc(
         self,
-        expression: Dict[Union[ExpressionField, float, int, str], Any],
+        expression: dict[Union[ExpressionField, float, int, str], Any],
         session: Optional[AsyncIOMotorClientSession] = None,
         bulk_writer: Optional[BulkWriter] = None,
         **kwargs: Any,
@@ -113,6 +112,4 @@ class UpdateMethods:
         :param bulk_writer: Optional[BulkWriter] - bulk writer
         :return: self
         """
-        return self.update(
-            Inc(expression), session=session, bulk_writer=bulk_writer, **kwargs
-        )
+        return self.update(Inc(expression), session=session, bulk_writer=bulk_writer, **kwargs)

--- a/beanie/odm/models.py
+++ b/beanie/odm/models.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 from beanie.odm.enums import InspectionStatuses
@@ -21,4 +19,4 @@ class InspectionResult(BaseModel):
     """
 
     status: InspectionStatuses = InspectionStatuses.OK
-    errors: List[InspectionError] = []
+    errors: list[InspectionError] = []

--- a/beanie/odm/operators/__init__.py
+++ b/beanie/odm/operators/__init__.py
@@ -1,8 +1,7 @@
 from abc import abstractmethod
 from collections.abc import Mapping
 from copy import copy, deepcopy
-from typing import Any, Dict
-from typing import Mapping as MappingType
+from typing import Any
 
 
 class BaseOperator(Mapping):
@@ -12,7 +11,7 @@ class BaseOperator(Mapping):
 
     @property
     @abstractmethod
-    def query(self) -> MappingType[str, Any]: ...
+    def query(self) -> Mapping[str, Any]: ...
 
     def __getitem__(self, item: str):
         return self.query[item]
@@ -32,7 +31,7 @@ class BaseOperator(Mapping):
     def __copy__(self):
         return copy(self.query)
 
-    def __deepcopy__(self, memodict: Dict[str, Any] = {}):
+    def __deepcopy__(self, memodict: dict[str, Any] = {}):
         return deepcopy(self.query)
 
     def copy(self):

--- a/beanie/odm/operators/find/element.py
+++ b/beanie/odm/operators/find/element.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List, Union
+from typing import Union
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -66,7 +66,7 @@ class Type(BaseFindElementOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/type/>
     """
 
-    def __init__(self, field, types: Union[List[str], str]):
+    def __init__(self, field, types: Union[list[str], str]):
         self.field = field
         self.types = types
 

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -177,9 +177,7 @@ class Text(BaseFindEvaluationOperator):
         if self.language:
             expression["$text"]["$language"] = self.language
         if self.diacritic_sensitive is not None:
-            expression["$text"]["$diacriticSensitive"] = (
-                self.diacritic_sensitive
-            )
+            expression["$text"]["$diacriticSensitive"] = self.diacritic_sensitive
         return expression
 
 

--- a/beanie/odm/operators/find/geospatial.py
+++ b/beanie/odm/operators/find/geospatial.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -50,7 +50,7 @@ class GeoIntersects(BaseFindGeospatialOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/geoIntersects/>
     """
 
-    def __init__(self, field, geo_type: str, coordinates: List[List[float]]):
+    def __init__(self, field, geo_type: str, coordinates: list[list[float]]):
         self.field = field
         self.geo_type = geo_type
         self.coordinates = coordinates
@@ -116,9 +116,7 @@ class GeoWithin(BaseFindGeospatialOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/geoWithin/>
     """
 
-    def __init__(
-        self, field, geo_type: GeoWithinTypes, coordinates: List[List[float]]
-    ):
+    def __init__(self, field, geo_type: GeoWithinTypes, coordinates: list[list[float]]):
         self.field = field
         self.geo_type = geo_type
         self.coordinates = coordinates
@@ -176,9 +174,7 @@ class Box(BaseFindGeospatialOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/box/>
     """
 
-    def __init__(
-        self, field, lower_left: List[float], upper_right: List[float]
-    ):
+    def __init__(self, field, lower_left: list[float], upper_right: list[float]):
         self.field = field
         self.coordinates = [lower_left, upper_right]
 
@@ -259,13 +255,9 @@ class Near(BaseFindGeospatialOperator):
             }
         }
         if self.max_distance:
-            expression[self.field][self.operator]["$maxDistance"] = (
-                self.max_distance
-            )  # type: ignore
+            expression[self.field][self.operator]["$maxDistance"] = self.max_distance  # type: ignore
         if self.min_distance:
-            expression[self.field][self.operator]["$minDistance"] = (
-                self.min_distance
-            )  # type: ignore
+            expression[self.field][self.operator]["$minDistance"] = self.min_distance  # type: ignore
         return expression
 
 

--- a/beanie/odm/operators/find/logical.py
+++ b/beanie/odm/operators/find/logical.py
@@ -1,5 +1,6 @@
 from abc import ABC
-from typing import Any, Dict, Mapping, Union
+from collections.abc import Mapping
+from typing import Any, Union
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -13,9 +14,7 @@ class LogicalOperatorForListOfExpressions(BaseFindLogicalOperator):
 
     def __init__(
         self,
-        *expressions: Union[
-            BaseFindOperator, Dict[str, Any], Mapping[str, Any], bool
-        ],
+        *expressions: Union[BaseFindOperator, dict[str, Any], Mapping[str, Any], bool],
     ):
         self.expressions = list(expressions)
 
@@ -108,9 +107,7 @@ class Nor(BaseFindLogicalOperator):
 
     def __init__(
         self,
-        *expressions: Union[
-            BaseFindOperator, Dict[str, Any], Mapping[str, Any], bool
-        ],
+        *expressions: Union[BaseFindOperator, dict[str, Any], Mapping[str, Any], bool],
     ):
         self.expressions = list(expressions)
 
@@ -151,9 +148,7 @@ class Not(BaseFindLogicalOperator):
         if len(self.expression) == 1:
             expression_key = list(self.expression.keys())[0]
             if expression_key.startswith("$"):
-                raise AttributeError(
-                    "Not operator can not be used with operators"
-                )
+                raise AttributeError("Not operator can not be used with operators")
             value = self.expression[expression_key]
             if isinstance(value, dict):
                 internal_key = list(value.keys())[0]
@@ -161,6 +156,4 @@ class Not(BaseFindLogicalOperator):
                     return {expression_key: {"$not": value}}
 
             return {expression_key: {"$not": {"$eq": value}}}
-        raise AttributeError(
-            "Not operator can only be used with one expression"
-        )
+        raise AttributeError("Not operator can only be used with one expression")

--- a/beanie/odm/operators/update/__init__.py
+++ b/beanie/odm/operators/update/__init__.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from beanie.odm.operators import BaseOperator
 

--- a/beanie/odm/queries/aggregation.py
+++ b/beanie/odm/queries/aggregation.py
@@ -1,11 +1,9 @@
+from collections.abc import Mapping
 from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
-    List,
-    Mapping,
     Optional,
-    Type,
     TypeVar,
 )
 
@@ -36,16 +34,14 @@ class AggregationQuery(
 
     def __init__(
         self,
-        document_model: Type["DocType"],
-        aggregation_pipeline: List[Mapping[str, Any]],
+        document_model: type["DocType"],
+        aggregation_pipeline: list[dict[str, Any]],
         find_query: Mapping[str, Any],
-        projection_model: Optional[Type[BaseModel]] = None,
+        projection_model: Optional[type[BaseModel]] = None,
         ignore_cache: bool = False,
         **pymongo_kwargs: Any,
     ):
-        self.aggregation_pipeline: List[Mapping[str, Any]] = (
-            aggregation_pipeline
-        )
+        self.aggregation_pipeline = aggregation_pipeline
         self.document_model = document_model
         self.projection_model = projection_model
         self.find_query = find_query
@@ -67,28 +63,22 @@ class AggregationQuery(
         )
 
     def _get_cache(self):
-        if (
-            self.document_model.get_settings().use_cache
-            and self.ignore_cache is False
-        ):
+        if self.document_model.get_settings().use_cache and self.ignore_cache is False:
             return self.document_model._cache.get(self._cache_key)  # type: ignore
         else:
             return None
 
     def _set_cache(self, data):
-        if (
-            self.document_model.get_settings().use_cache
-            and self.ignore_cache is False
-        ):
+        if self.document_model.get_settings().use_cache and self.ignore_cache is False:
             return self.document_model._cache.set(self._cache_key, data)  # type: ignore
 
     def get_aggregation_pipeline(
         self,
-    ) -> List[Mapping[str, Any]]:
-        match_pipeline: List[Mapping[str, Any]] = (
+    ) -> list[dict[str, Any]]:
+        match_pipeline: list[dict[str, Any]] = (
             [{"$match": self.find_query}] if self.find_query else []
         )
-        projection_pipeline: List[Mapping[str, Any]] = []
+        projection_pipeline: list[dict[str, Any]] = []
         if self.projection_model:
             projection = get_projection(self.projection_model)
             if projection is not None:
@@ -102,5 +92,5 @@ class AggregationQuery(
             aggregation_pipeline, session=self.session, **self.pymongo_kwargs
         )
 
-    def get_projection_model(self) -> Optional[Type[BaseModel]]:
+    def get_projection_model(self) -> Optional[type[BaseModel]]:
         return self.projection_model

--- a/beanie/odm/queries/delete.py
+++ b/beanie/odm/queries/delete.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, Generator, Mapping, Optional, Type
+from collections.abc import Generator, Mapping
+from typing import TYPE_CHECKING, Any, Optional
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 from pymongo import DeleteMany as DeleteManyPyMongo
@@ -20,7 +21,7 @@ class DeleteQuery(SessionMethods, CloneInterface):
 
     def __init__(
         self,
-        document_model: Type["DocType"],
+        document_model: type["DocType"],
         find_query: Mapping[str, Any],
         bulk_writer: Optional[BulkWriter] = None,
         **pymongo_kwargs: Any,
@@ -29,7 +30,7 @@ class DeleteQuery(SessionMethods, CloneInterface):
         self.find_query = find_query
         self.session: Optional[AsyncIOMotorClientSession] = None
         self.bulk_writer = bulk_writer
-        self.pymongo_kwargs: Dict[str, Any] = pymongo_kwargs
+        self.pymongo_kwargs: dict[str, Any] = pymongo_kwargs
 
 
 class DeleteMany(DeleteQuery):

--- a/beanie/odm/registry.py
+++ b/beanie/odm/registry.py
@@ -1,31 +1,28 @@
-from typing import Dict, ForwardRef, Type, Union
+from typing import ForwardRef, Union
 
 from pydantic import BaseModel
 
 
 class DocsRegistry:
-    _registry: Dict[str, Type[BaseModel]] = {}
+    _registry: dict[str, type[BaseModel]] = {}
 
     @classmethod
-    def register(cls, name: str, doc_type: Type[BaseModel]):
+    def register(cls, name: str, doc_type: type[BaseModel]):
         cls._registry[name] = doc_type
 
     @classmethod
-    def get(cls, name: str) -> Type[BaseModel]:
+    def get(cls, name: str) -> type[BaseModel]:
         return cls._registry[name]
 
     @classmethod
-    def evaluate_fr(cls, forward_ref: Union[ForwardRef, Type]):
+    def evaluate_fr(cls, forward_ref: Union[ForwardRef, type]):
         """
         Evaluate forward ref
 
         :param forward_ref: ForwardRef - forward ref to evaluate
         :return: Type[BaseModel] - class of the forward ref
         """
-        if (
-            isinstance(forward_ref, ForwardRef)
-            and forward_ref.__forward_arg__ in cls._registry
-        ):
+        if isinstance(forward_ref, ForwardRef) and forward_ref.__forward_arg__ in cls._registry:
             return cls._registry[forward_ref.__forward_arg__]
         else:
             return forward_ref

--- a/beanie/odm/settings/base.py
+++ b/beanie/odm/settings/base.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Dict, Optional, Type
+from typing import Any, Optional
 
 from motor.motor_asyncio import AsyncIOMotorCollection, AsyncIOMotorDatabase
 from pydantic import BaseModel, Field
@@ -16,13 +16,13 @@ class ItemSettings(BaseModel):
     use_cache: bool = False
     cache_capacity: int = 32
     cache_expiration_time: timedelta = timedelta(minutes=10)
-    bson_encoders: Dict[Any, Any] = Field(default_factory=dict)
-    projection: Optional[Dict[str, Any]] = None
+    bson_encoders: dict[Any, Any] = Field(default_factory=dict)
+    projection: Optional[dict[str, Any]] = None
 
     motor_db: Optional[AsyncIOMotorDatabase] = None
     motor_collection: Optional[AsyncIOMotorCollection] = None
 
-    union_doc: Optional[Type] = None
+    union_doc: Optional[type] = None
     union_doc_alias: Optional[str] = None
     class_id: str = "_class_id"
 

--- a/beanie/odm/settings/document.py
+++ b/beanie/odm/settings/document.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import Field
 
@@ -19,7 +19,7 @@ class DocumentSettings(ItemSettings):
     use_revision: bool = False
     single_root_inheritance: bool = False
 
-    indexes: List[IndexModelField] = Field(default_factory=list)
+    indexes: list[IndexModelField] = Field(default_factory=list)
     merge_indexes: bool = False
     timeseries: Optional[TimeSeriesConfig] = None
 

--- a/beanie/odm/settings/timeseries.py
+++ b/beanie/odm/settings/timeseries.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -26,16 +26,15 @@ class TimeSeriesConfig(BaseModel):
     bucket_rounding_second: Annotated[
         Optional[int],
         Field(
-            deprecated="This field is deprecated in favor of "
-            "'bucket_rounding_seconds'.",
+            deprecated="This field is deprecated in favor of 'bucket_rounding_seconds'.",
         ),
     ] = None
     bucket_rounding_seconds: Optional[int] = None
     expire_after_seconds: Optional[int] = None
 
-    def build_query(self, collection_name: str) -> Dict[str, Any]:
-        res: Dict[str, Any] = {"name": collection_name}
-        timeseries: Dict[str, Any] = {"timeField": self.time_field}
+    def build_query(self, collection_name: str) -> dict[str, Any]:
+        res: dict[str, Any] = {"name": collection_name}
+        timeseries: dict[str, Any] = {"timeField": self.time_field}
         if self.meta_field is not None:
             timeseries["metaField"] = self.meta_field
         if self.granularity is not None:

--- a/beanie/odm/settings/view.py
+++ b/beanie/odm/settings/view.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Type, Union
+from typing import Any, Union
 
 from pydantic import Field
 
@@ -6,8 +6,8 @@ from beanie.odm.settings.base import ItemSettings
 
 
 class ViewSettings(ItemSettings):
-    source: Union[str, Type]
-    pipeline: List[Dict[str, Any]]
+    source: Union[str, type]
+    pipeline: list[dict[str, Any]]
 
     max_nesting_depths_per_field: dict = Field(default_factory=dict)
     max_nesting_depth: int = 3

--- a/beanie/odm/union_doc.py
+++ b/beanie/odm/union_doc.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, Optional, Type, TypeVar
+from typing import Any, ClassVar, Optional, TypeVar
 
 from motor.motor_asyncio import AsyncIOMotorClientSession
 
@@ -19,7 +19,7 @@ class UnionDoc(
     OtherGettersInterface,
     DetectionInterface,
 ):
-    _document_models: ClassVar[Optional[Dict[str, Type]]] = None
+    _document_models: ClassVar[Optional[dict[str, type]]] = None
     _is_inited: ClassVar[bool] = False
     _settings: ClassVar[UnionDocSettings]
 
@@ -28,7 +28,7 @@ class UnionDoc(
         return cls._settings
 
     @classmethod
-    def register_doc(cls, name: str, doc_model: Type):
+    def register_doc(cls, name: str, doc_model: type):
         if cls._document_models is None:
             cls._document_models = {}
 
@@ -76,6 +76,4 @@ class UnionDoc(
             async with Document.bulk_writer(ordered=True) as bulk:
                 await Document.insert_one(Document(field="value"), bulk_writer=bulk)
         """
-        return BulkWriter(
-            session, ordered, cls, bypass_document_validation, comment
-        )
+        return BulkWriter(session, ordered, cls, bypass_document_validation, comment)

--- a/beanie/odm/utils/dump.py
+++ b/beanie/odm/utils/dump.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Set
+from typing import TYPE_CHECKING, Optional
 
 from beanie.odm.utils.encoder import Encoder
 
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 def get_dict(
     document: "Document",
     to_db: bool = False,
-    exclude: Optional[Set[str]] = None,
+    exclude: Optional[set[str]] = None,
     keep_nulls: bool = True,
 ):
     if exclude is None:
@@ -24,7 +24,7 @@ def get_dict(
 
 def get_nulls(
     document: "Document",
-    exclude: Optional[Set[str]] = None,
+    exclude: Optional[set[str]] = None,
 ):
     dictionary = get_dict(document, exclude=exclude, keep_nulls=True)
     return filter_none(dictionary)
@@ -32,7 +32,7 @@ def get_nulls(
 
 def get_top_level_nones(
     document: "Document",
-    exclude: Optional[Set[str]] = None,
+    exclude: Optional[set[str]] = None,
 ):
     dictionary = get_dict(document, exclude=exclude, keep_nulls=True)
     return {k: v for k, v in dictionary.items() if v is None}

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -7,16 +7,12 @@ import operator
 import pathlib
 import re
 import uuid
+from collections.abc import Container, Iterable, Mapping, MutableMapping
 from enum import Enum
 from typing import (
     Any,
     Callable,
-    Container,
-    Iterable,
-    Mapping,
-    MutableMapping,
     Optional,
-    Tuple,
 )
 
 import bson
@@ -83,9 +79,7 @@ class Encoder:
     """
 
     exclude: Container[str] = frozenset()
-    custom_encoders: Mapping[type, SingleArgCallable] = dc.field(
-        default_factory=dict
-    )
+    custom_encoders: Mapping[type, SingleArgCallable] = dc.field(default_factory=dict)
     to_db: bool = False
     keep_nulls: bool = True
 
@@ -94,9 +88,7 @@ class Encoder:
         settings = obj.get_settings()
         obj_dict = {}
         if settings.union_doc is not None:
-            obj_dict[settings.class_id] = (
-                settings.union_doc_alias or obj.__class__.__name__
-            )
+            obj_dict[settings.class_id] = settings.union_doc_alias or obj.__class__.__name__
         if obj._class_id:
             obj_dict[settings.class_id] = obj._class_id
 
@@ -151,9 +143,7 @@ class Encoder:
 
         raise ValueError(f"Cannot encode {obj!r}")
 
-    def _iter_model_items(
-        self, obj: pydantic.BaseModel
-    ) -> Iterable[Tuple[str, Any]]:
+    def _iter_model_items(self, obj: pydantic.BaseModel) -> Iterable[tuple[str, Any]]:
         exclude, keep_nulls = self.exclude, self.keep_nulls
         get_model_field = get_model_fields(obj).get
         for key, value in obj.__iter__():

--- a/beanie/odm/utils/parsing.py
+++ b/beanie/odm/utils/parsing.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Type, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from pydantic import BaseModel
 
@@ -25,9 +25,7 @@ def merge_models(left: BaseModel, right: BaseModel) -> None:
 
     for k, right_value in right.__iter__():
         left_value = getattr(left, k, None)
-        if isinstance(right_value, BaseModel) and isinstance(
-            left_value, BaseModel
-        ):
+        if isinstance(right_value, BaseModel) and isinstance(left_value, BaseModel):
             if get_config_value(left_value, "frozen"):
                 left.__setattr__(k, right_value)
             else:
@@ -46,9 +44,7 @@ def merge_models(left: BaseModel, right: BaseModel) -> None:
             left.__setattr__(k, right_value)
 
 
-def apply_changes(
-    changes: Dict[str, Any], target: Union[BaseModel, Dict[str, Any]]
-):
+def apply_changes(changes: dict[str, Any], target: Union[BaseModel, dict[str, Any]]):
     for key, value in changes.items():
         if "." in key:
             key_parts = key.split(".")
@@ -60,31 +56,23 @@ def apply_changes(
                     elif isinstance(current_target, BaseModel):
                         current_target = getattr(current_target, part)
                     else:
-                        raise ApplyChangesException(
-                            f"Unexpected type of target: {type(target)}"
-                        )
+                        raise ApplyChangesException(f"Unexpected type of target: {type(target)}")
                 final_key = key_parts[-1]
                 if isinstance(current_target, dict):
                     current_target[final_key] = value
                 elif isinstance(current_target, BaseModel):
                     setattr(current_target, final_key, value)
                 else:
-                    raise ApplyChangesException(
-                        f"Unexpected type of target: {type(target)}"
-                    )
+                    raise ApplyChangesException(f"Unexpected type of target: {type(target)}")
             except (KeyError, AttributeError) as e:
-                raise ApplyChangesException(
-                    f"Failed to apply change for key '{key}': {e}"
-                )
+                raise ApplyChangesException(f"Failed to apply change for key '{key}': {e}")
         else:
             if isinstance(target, dict):
                 target[key] = value
             elif isinstance(target, BaseModel):
                 setattr(target, key, value)
             else:
-                raise ApplyChangesException(
-                    f"Unexpected type of target: {type(target)}"
-                )
+                raise ApplyChangesException(f"Unexpected type of target: {type(target)}")
 
 
 def save_state(item: BaseModel):
@@ -93,13 +81,12 @@ def save_state(item: BaseModel):
 
 
 def parse_obj(
-    model: Union[Type[BaseModel], Type["Document"]],
+    model: Union[type[BaseModel], type["Document"]],
     data: Any,
     lazy_parse: bool = False,
 ) -> BaseModel:
     if (
-        hasattr(model, "get_model_type")
-        and model.get_model_type() == ModelType.UnionDoc  # type: ignore
+        hasattr(model, "get_model_type") and model.get_model_type() == ModelType.UnionDoc  # type: ignore
     ):
         if model._document_models is None:  # type: ignore
             raise UnionHasNoRegisteredDocs

--- a/beanie/odm/utils/projection.py
+++ b/beanie/odm/utils/projection.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Type, TypeVar
+from typing import Optional, TypeVar
 
 from pydantic import BaseModel
 
@@ -9,8 +9,8 @@ ProjectionModelType = TypeVar("ProjectionModelType", bound=BaseModel)
 
 
 def get_projection(
-    model: Type[ProjectionModelType],
-) -> Optional[Dict[str, int]]:
+    model: type[ProjectionModelType],
+) -> Optional[dict[str, int]]:
     if hasattr(model, "get_model_type") and (
         model.get_model_type() == ModelType.UnionDoc  # type: ignore
         or (  # type: ignore
@@ -21,15 +21,15 @@ def get_projection(
         return None
 
     if hasattr(model, "Settings"):  # MyPy checks
-        settings = getattr(model, "Settings")
+        settings = model.Settings
 
         if hasattr(settings, "projection"):
-            return getattr(settings, "projection")
+            return settings.projection
 
     if get_config_value(model, "extra") == "allow":
         return None
 
-    document_projection: Dict[str, int] = {}
+    document_projection: dict[str, int] = {}
 
     for name, field in get_model_fields(model).items():
         document_projection[field.alias or name] = 1

--- a/beanie/odm/utils/pydantic.py
+++ b/beanie/odm/utils/pydantic.py
@@ -1,12 +1,10 @@
-from typing import Any, Type
+from typing import Any
 
 import pydantic
 from pydantic import BaseModel
 
 IS_PYDANTIC_V2 = int(pydantic.VERSION.split(".")[0]) >= 2
-IS_PYDANTIC_V2_10 = (
-    IS_PYDANTIC_V2 and int(pydantic.VERSION.split(".")[1]) >= 10
-)
+IS_PYDANTIC_V2_10 = IS_PYDANTIC_V2 and int(pydantic.VERSION.split(".")[1]) >= 10
 
 if IS_PYDANTIC_V2:
     from pydantic import TypeAdapter
@@ -14,7 +12,7 @@ else:
     from pydantic import parse_obj_as
 
 
-def parse_object_as(object_type: Type, data: Any):
+def parse_object_as(object_type: type, data: Any):
     if IS_PYDANTIC_V2:
         return TypeAdapter(object_type).validate_python(data)
     else:
@@ -35,7 +33,7 @@ def get_model_fields(model):
         return model.__fields__
 
 
-def parse_model(model_type: Type[BaseModel], data: Any):
+def parse_model(model_type: type[BaseModel], data: Any):
     if IS_PYDANTIC_V2:
         return model_type.model_validate(data)
     else:

--- a/beanie/odm/utils/relations.py
+++ b/beanie/odm/utils/relations.py
@@ -1,21 +1,15 @@
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Dict
-from typing import Mapping as MappingType
+from typing import TYPE_CHECKING, Any
 
 from beanie.odm.fields import (
     ExpressionField,
 )
 
-# from pydantic.fields import ModelField
-# from pydantic.typing import get_origin
-
 if TYPE_CHECKING:
     from beanie import Document
 
 
-def convert_ids(
-    query: MappingType[str, Any], doc: "Document", fetch_links: bool
-) -> Dict[str, Any]:
+def convert_ids(query: Mapping[str, Any], doc: "Document", fetch_links: bool) -> dict[str, Any]:
     # TODO add all the cases
     new_query = {}
     for k, v in query.items():
@@ -38,10 +32,7 @@ def convert_ids(
             new_v = convert_ids(v, doc, fetch_links)
         elif isinstance(v, list):
             new_v = [
-                convert_ids(ele, doc, fetch_links)
-                if isinstance(ele, Mapping)
-                else ele
-                for ele in v
+                convert_ids(ele, doc, fetch_links) if isinstance(ele, Mapping) else ele for ele in v
             ]
         else:
             new_v = v

--- a/beanie/odm/utils/state.py
+++ b/beanie/odm/utils/state.py
@@ -15,9 +15,7 @@ R = TypeVar("R")
 
 def check_if_state_saved(self: "DocType"):
     if not self.use_state_management():
-        raise StateManagementIsTurnedOff(
-            "State management is turned off for this document"
-        )
+        raise StateManagementIsTurnedOff("State management is turned off for this document")
     if self._saved_state is None:
         raise StateNotSaved("No state was saved")
 
@@ -31,9 +29,7 @@ def saved_state_needed(
         return f(self, *args, **kwargs)
 
     @wraps(f)
-    async def async_wrapper(
-        self: "DocType", *args: P.args, **kwargs: P.kwargs
-    ) -> R:
+    async def async_wrapper(self: "DocType", *args: P.args, **kwargs: P.kwargs) -> R:
         check_if_state_saved(self)
         # type ignore because there is no nice/proper way to annotate both sync
         # and async case without parametrized TypeVar, which is not supported
@@ -48,9 +44,7 @@ def saved_state_needed(
 
 def check_if_previous_state_saved(self: "DocType"):
     if not self.use_state_management():
-        raise StateManagementIsTurnedOff(
-            "State management is turned off for this document"
-        )
+        raise StateManagementIsTurnedOff("State management is turned off for this document")
     if not self.state_management_save_previous():
         raise StateManagementIsTurnedOff(
             "State management's option to save previous state is turned off for this document"
@@ -66,9 +60,7 @@ def previous_saved_state_needed(
         return f(self, *args, **kwargs)
 
     @wraps(f)
-    async def async_wrapper(
-        self: "DocType", *args: P.args, **kwargs: P.kwargs
-    ) -> R:
+    async def async_wrapper(self: "DocType", *args: P.args, **kwargs: P.kwargs) -> R:
         check_if_previous_state_saved(self)
         # type ignore because there is no nice/proper way to annotate both sync
         # and async case without parametrized TypeVar, which is not supported

--- a/beanie/odm/views.py
+++ b/beanie/odm/views.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, ClassVar, Dict, Optional, Union
+from typing import Any, ClassVar, Optional, Union
 
 from pydantic import BaseModel
 
@@ -28,7 +28,7 @@ class View(
     """
 
     # Relations
-    _link_fields: ClassVar[Optional[Dict[str, LinkInfo]]] = None
+    _link_fields: ClassVar[Optional[dict[str, LinkInfo]]] = None
 
     # Settings
     _settings: ClassVar[ViewSettings]
@@ -63,7 +63,7 @@ class View(
         await asyncio.gather(*coros)
 
     @classmethod
-    def get_link_fields(cls) -> Optional[Dict[str, LinkInfo]]:
+    def get_link_fields(cls) -> Optional[dict[str, LinkInfo]]:
         return cls._link_fields
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,15 +117,67 @@ ignore_missing_imports = true
 include = ["tests/typing", "beanie"]
 
 [tool.ruff]
-line-length = 79
-fix = true
-target-version = "py312"
-include = ["**/*.py", ".github/**/*.py"]
+line-length = 100
+fix = false
+target-version = "py39"
+exclude = [
+    ".git",
+    ".mypy_cache",
+    ".vscode",
+    "__pycache__",
+    ".ruff_cache",
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    "docs"
+]
+
+[tool.ruff.lint.pycodestyle]
+# max-doc-length = 72 # PEP-8
 
 [tool.ruff.lint]
-ignore = ["E501"]
-extend-select = ["I001"]
-per-file-ignores = { "tests/*" = ["E711"] }
-
+preview = true
+select =  [
+    # pycodestyle
+    "E",
+    "W",
+     # isort
+    "I",
+    # pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # Ruff specific
+    "RUF"
+]
+ignore = [
+    "E501",
+    "RUF005",
+    "RUF012",
+    "RUF022",
+    "SIM112",
+    # Ignored for now, pending fix
+    "B006",
+    "B904",
+    "RUF015",
+    "RUF036",
+    "SIM102",
+    "SIM103",
+    "SIM108",
+    "SIM118"
+]
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    # Allow lambda expressions in tests
+    "E711",
+    # Suppress useless attribute access in tests
+    "B018"
+]

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,7 +1,6 @@
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Set
 
 import requests  # type: ignore
 
@@ -31,7 +30,7 @@ class ChangelogGenerator:
         self.commits = self.get_commits_after_tag(current_version)
         self.prs = self.get_prs_for_commits(self.commits)
 
-    def get_commits_after_tag(self, tag: str) -> List[str]:
+    def get_commits_after_tag(self, tag: str) -> list[str]:
         result = subprocess.run(
             ["git", "log", f"{tag}..HEAD", "--pretty=format:%H"],
             stdout=subprocess.PIPE,
@@ -52,9 +51,9 @@ class ChangelogGenerator:
             url=pr_data["html_url"],
         )
 
-    def get_prs_for_commits(self, commit_shas: List[str]) -> List[PullRequest]:
-        prs: List[PullRequest] = []
-        unique_prs: Set[int] = set()
+    def get_prs_for_commits(self, commit_shas: list[str]) -> list[PullRequest]:
+        prs: list[PullRequest] = []
+        unique_prs: set[int] = set()
         for commit_sha in commit_shas:
             pr = self.get_pr_for_commit(commit_sha)
             pr_id = pr.number

--- a/tests/fastapi/conftest.py
+++ b/tests/fastapi/conftest.py
@@ -18,9 +18,7 @@ async def api_client(clean_db):
     """api client fixture."""
     async with LifespanManager(app, startup_timeout=100, shutdown_timeout=100):
         server_name = "http://localhost"
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url=server_name
-        ) as ac:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=server_name) as ac:
             yield ac
 
 

--- a/tests/fastapi/models.py
+++ b/tests/fastapi/models.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import Field
 
 from beanie import Document, Indexed, Link
@@ -21,7 +19,7 @@ class RoofAPI(Document):
 
 
 class HouseAPI(Document):
-    windows: List[Link[WindowAPI]]
+    windows: list[Link[WindowAPI]]
     name: Indexed(str)
     height: Indexed(int) = 2
 

--- a/tests/fastapi/routes.py
+++ b/tests/fastapi/routes.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import APIRouter, Body, status
+from fastapi import APIRouter, status
 from pydantic import BaseModel
 
 from beanie import PydanticObjectId, WriteRules
@@ -44,12 +44,8 @@ async def create_house(window: WindowAPI):
 
 @house_router.post("/houses_with_window_link/", response_model=HouseAPI)
 async def create_houses_with_window_link(window: WindowInput):
-    validator = (
-        HouseAPI.model_validate if IS_PYDANTIC_V2 else HouseAPI.parse_obj
-    )
-    house = validator(
-        dict(name="test_name", windows=[WindowAPI.link_from_id(window.id)])
-    )
+    validator = HouseAPI.model_validate if IS_PYDANTIC_V2 else HouseAPI.parse_obj
+    house = validator(dict(name="test_name", windows=[WindowAPI.link_from_id(window.id)]))
     await house.insert(link_rule=WriteRules.WRITE)
     return house
 
@@ -65,7 +61,7 @@ async def create_houses_2(house: HouseAPI):
     response_model=House,
     status_code=status.HTTP_201_CREATED,
 )
-async def create_house_new(house: House = Body(...)):
+async def create_house_new(house: House):
     person = Person(name="Bob")
     house.owner = person
     await house.save(link_rule=WriteRules.WRITE)

--- a/tests/migrations/migrations_for_test/break/20210413211219_break.py
+++ b/tests/migrations/migrations_for_test/break/20210413211219_break.py
@@ -30,9 +30,7 @@ fixed_id = PydanticObjectId("6076f1f3e4b7f6b7a0f6e5a0")
 
 class Forward:
     @iterative_migration(batch_size=2)
-    async def name_to_title(
-        self, input_document: OldNote, output_document: Note
-    ):
+    async def name_to_title(self, input_document: OldNote, output_document: Note):
         output_document.title = input_document.name
         if output_document.title > "5":
             output_document.name = "5"
@@ -40,7 +38,5 @@ class Forward:
 
 class Backward:
     @iterative_migration()
-    async def title_to_name(
-        self, input_document: Note, output_document: OldNote
-    ):
+    async def title_to_name(self, input_document: Note, output_document: OldNote):
         output_document.name = input_document.title

--- a/tests/migrations/migrations_for_test/change_subfield/20210413152406_change_subfield.py
+++ b/tests/migrations/migrations_for_test/change_subfield/20210413152406_change_subfield.py
@@ -31,15 +31,11 @@ class Note(Document):
 
 class Forward:
     @iterative_migration()
-    async def change_color(
-        self, input_document: OldNote, output_document: Note
-    ):
+    async def change_color(self, input_document: OldNote, output_document: Note):
         output_document.tag.title = input_document.tag.name
 
 
 class Backward:
     @iterative_migration()
-    async def change_title(
-        self, input_document: Note, output_document: OldNote
-    ):
+    async def change_title(self, input_document: Note, output_document: OldNote):
         output_document.tag.name = input_document.tag.title

--- a/tests/migrations/migrations_for_test/free_fall/20210413210446_free_fall.py
+++ b/tests/migrations/migrations_for_test/free_fall/20210413210446_free_fall.py
@@ -28,9 +28,7 @@ class Forward:
     @free_fall_migration(document_models=[OldNote, Note])
     async def name_to_title(self, session):
         async for old_note in OldNote.find_all():
-            new_note = Note(
-                id=old_note.id, title=old_note.name, tag=old_note.tag
-            )
+            new_note = Note(id=old_note.id, title=old_note.name, tag=old_note.tag)
             await new_note.replace(session=session)
 
 
@@ -38,7 +36,5 @@ class Backward:
     @free_fall_migration(document_models=[OldNote, Note])
     async def title_to_name(self, session):
         async for old_note in Note.find_all():
-            new_note = OldNote(
-                id=old_note.id, name=old_note.title, tag=old_note.tag
-            )
+            new_note = OldNote(id=old_note.id, name=old_note.title, tag=old_note.tag)
             await new_note.replace(session=session)

--- a/tests/migrations/migrations_for_test/many_migrations/20210413170728_4_5.py
+++ b/tests/migrations/migrations_for_test/many_migrations/20210413170728_4_5.py
@@ -18,31 +18,23 @@ class Note(Document):
 
 class Forward:
     @iterative_migration()
-    async def change_title_4(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_4(self, input_document: Note, output_document: Note):
         if input_document.title == "4":
             output_document.title = "four"
 
     @iterative_migration()
-    async def change_title_5(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_5(self, input_document: Note, output_document: Note):
         if input_document.title == "5":
             output_document.title = "five"
 
 
 class Backward:
     @iterative_migration()
-    async def change_title_5(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_5(self, input_document: Note, output_document: Note):
         if input_document.title == "five":
             output_document.title = "5"
 
     @iterative_migration()
-    async def change_title_4(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_4(self, input_document: Note, output_document: Note):
         if input_document.title == "four":
             output_document.title = "4"

--- a/tests/migrations/migrations_for_test/many_migrations/20210413170734_6_7.py
+++ b/tests/migrations/migrations_for_test/many_migrations/20210413170734_6_7.py
@@ -18,31 +18,23 @@ class Note(Document):
 
 class Forward:
     @iterative_migration()
-    async def change_title_6(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_6(self, input_document: Note, output_document: Note):
         if input_document.title == "6":
             output_document.title = "six"
 
     @iterative_migration()
-    async def change_title_7(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_7(self, input_document: Note, output_document: Note):
         if input_document.title == "7":
             output_document.title = "seven"
 
 
 class Backward:
     @iterative_migration()
-    async def change_title_7(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_7(self, input_document: Note, output_document: Note):
         if input_document.title == "seven":
             output_document.title = "7"
 
     @iterative_migration()
-    async def change_title_6(
-        self, input_document: Note, output_document: Note
-    ):
+    async def change_title_6(self, input_document: Note, output_document: Note):
         if input_document.title == "six":
             output_document.title = "6"

--- a/tests/migrations/migrations_for_test/pack_unpack/20210413135927_pack_unpack.py
+++ b/tests/migrations/migrations_for_test/pack_unpack/20210413135927_pack_unpack.py
@@ -28,9 +28,7 @@ class Note(Document):
 class Forward:
     @iterative_migration()
     async def pack(self, input_document: OldNote, output_document: Note):
-        output_document.tag = Tag(
-            name=input_document.tag_name, color=input_document.tag_color
-        )
+        output_document.tag = Tag(name=input_document.tag_name, color=input_document.tag_color)
 
 
 class Backward:

--- a/tests/migrations/migrations_for_test/remove_index/20210414135045_remove_index.py
+++ b/tests/migrations/migrations_for_test/remove_index/20210414135045_remove_index.py
@@ -30,13 +30,9 @@ class Note(Document):
 
 class Forward:
     @iterative_migration()
-    async def name_to_title(
-        self, input_document: OldNote, output_document: Note
-    ): ...
+    async def name_to_title(self, input_document: OldNote, output_document: Note): ...
 
 
 class Backward:
     @iterative_migration()
-    async def title_to_name(
-        self, input_document: Note, output_document: OldNote
-    ): ...
+    async def title_to_name(self, input_document: Note, output_document: OldNote): ...

--- a/tests/migrations/migrations_for_test/rename_field/20210407203225_rename_field.py
+++ b/tests/migrations/migrations_for_test/rename_field/20210407203225_rename_field.py
@@ -26,15 +26,11 @@ class Note(Document):
 
 class Forward:
     @iterative_migration()
-    async def name_to_title(
-        self, input_document: OldNote, output_document: Note
-    ):
+    async def name_to_title(self, input_document: OldNote, output_document: Note):
         output_document.title = input_document.name
 
 
 class Backward:
     @iterative_migration()
-    async def title_to_name(
-        self, input_document: Note, output_document: OldNote
-    ):
+    async def title_to_name(self, input_document: Note, output_document: OldNote):
         output_document.name = input_document.title

--- a/tests/migrations/test_break.py
+++ b/tests/migrations/test_break.py
@@ -1,5 +1,6 @@
 import pytest
 from pydantic.main import BaseModel
+from pymongo.errors import BulkWriteError
 
 from beanie import Indexed, init_beanie
 from beanie.executors.migrate import MigrationSettings, run_migrate
@@ -49,7 +50,7 @@ async def test_migration_break(settings, notes, db):
         database_name=settings.mongodb_db_name,
         path="tests/migrations/migrations_for_test/break",
     )
-    with pytest.raises(Exception):
+    with pytest.raises(BulkWriteError):
         await run_migrate(migration_settings)
 
     await init_beanie(database=db, document_models=[OldNote])

--- a/tests/migrations/test_remove_indexes.py
+++ b/tests/migrations/test_remove_indexes.py
@@ -49,9 +49,7 @@ async def test_remove_index_allowed(settings, notes, db):
     )
     await run_migrate(migration_settings)
 
-    await init_beanie(
-        database=db, document_models=[Note], allow_index_dropping=False
-    )
+    await init_beanie(database=db, document_models=[Note], allow_index_dropping=False)
     collection: AsyncIOMotorCollection = Note.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info == {
@@ -67,9 +65,7 @@ async def test_remove_index_default(settings, notes, db):
     )
     await run_migrate(migration_settings)
 
-    await init_beanie(
-        database=db, document_models=[Note], allow_index_dropping=False
-    )
+    await init_beanie(database=db, document_models=[Note], allow_index_dropping=False)
     collection: AsyncIOMotorCollection = Note.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info == {
@@ -87,9 +83,7 @@ async def test_remove_index_not_allowed(settings, notes, db):
     )
     await run_migrate(migration_settings)
 
-    await init_beanie(
-        database=db, document_models=[Note], allow_index_dropping=False
-    )
+    await init_beanie(database=db, document_models=[Note], allow_index_dropping=False)
     collection: AsyncIOMotorCollection = Note.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info == {

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -1,7 +1,7 @@
 import warnings
 from datetime import datetime, timedelta, timezone
 from random import randint
-from typing import List
+from typing import Optional
 
 import pytest
 
@@ -356,8 +356,8 @@ def document_not_inserted():
 @pytest.fixture
 def documents_not_inserted():
     def generate_documents(
-        number: int, test_str: str = None, random: bool = False
-    ) -> List[DocumentTestModel]:
+        number: int, test_str: Optional[str] = None, random: bool = False
+    ) -> list[DocumentTestModel]:
         return [
             DocumentTestModel(
                 test_int=randint(0, 1000000) if random else i,
@@ -385,7 +385,7 @@ def document_soft_delete_not_inserted():
 @pytest.fixture
 def documents_soft_delete_not_inserted():
     docs = []
-    for i in range(3):
+    for _ in range(3):
         docs.append(
             DocumentTestModelWithSoftDelete(
                 test_int=randint(0, 1000000),
@@ -402,9 +402,7 @@ async def document(document_not_inserted) -> DocumentTestModel:
 
 @pytest.fixture
 def documents(documents_not_inserted):
-    async def generate_documents(
-        number: int, test_str: str = None, random: bool = False
-    ):
+    async def generate_documents(number: int, test_str: Optional[str] = None, random: bool = False):
         result = await DocumentTestModel.insert_many(
             documents_not_inserted(number, test_str, random)
         )

--- a/tests/odm/documents/test_aggregate.py
+++ b/tests/odm/documents/test_aggregate.py
@@ -23,9 +23,7 @@ async def test_aggregate_with_filter(documents):
     await documents(1, "cuatro")
     result = (
         await DocumentTestModel.find(DocumentTestModel.test_int >= 1)
-        .aggregate(
-            [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
-        )
+        .aggregate([{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}])
         .to_list()
     )
     assert len(result) == 2

--- a/tests/odm/documents/test_bulk_write.py
+++ b/tests/odm/documents/test_bulk_write.py
@@ -15,12 +15,8 @@ from tests.odm.models import (
 async def test_insert(documents_not_inserted):
     documents = documents_not_inserted(2)
     async with BulkWriter() as bulk_writer:
-        await DocumentTestModel.insert_one(
-            documents[0], bulk_writer=bulk_writer
-        )
-        await DocumentTestModel.insert_one(
-            documents[1], bulk_writer=bulk_writer
-        )
+        await DocumentTestModel.insert_one(documents[0], bulk_writer=bulk_writer)
+        await DocumentTestModel.insert_one(documents[1], bulk_writer=bulk_writer)
 
     new_documents = await DocumentTestModel.find_all().to_list()
     assert len(new_documents) == 2
@@ -32,9 +28,7 @@ async def test_update(documents):
     doc.test_int = 100
     async with BulkWriter() as bulk_writer:
         await doc.save_changes(bulk_writer=bulk_writer)
-        await DocumentTestModel.find_one(
-            DocumentTestModel.test_int == 1
-        ).update(
+        await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).update(
             Set({DocumentTestModel.test_int: 1000}), bulk_writer=bulk_writer
         )
         await DocumentTestModel.find(DocumentTestModel.test_int < 100).update(
@@ -42,30 +36,9 @@ async def test_update(documents):
         )
 
     assert len(await DocumentTestModel.find_all().to_list()) == 5
-    assert (
-        len(
-            await DocumentTestModel.find(
-                DocumentTestModel.test_int == 100
-            ).to_list()
-        )
-        == 1
-    )
-    assert (
-        len(
-            await DocumentTestModel.find(
-                DocumentTestModel.test_int == 1000
-            ).to_list()
-        )
-        == 1
-    )
-    assert (
-        len(
-            await DocumentTestModel.find(
-                DocumentTestModel.test_int == 2000
-            ).to_list()
-        )
-        == 3
-    )
+    assert len(await DocumentTestModel.find(DocumentTestModel.test_int == 100).to_list()) == 1
+    assert len(await DocumentTestModel.find(DocumentTestModel.test_int == 1000).to_list()) == 1
+    assert len(await DocumentTestModel.find(DocumentTestModel.test_int == 2000).to_list()) == 3
 
 
 async def test_unordered_update(documents, document):
@@ -74,20 +47,11 @@ async def test_unordered_update(documents, document):
     doc.test_int = 100
     with pytest.raises(BulkWriteError):
         async with BulkWriter(ordered=False) as bulk_writer:
-            await DocumentTestModel.insert_one(
-                document, bulk_writer=bulk_writer
-            )
+            await DocumentTestModel.insert_one(document, bulk_writer=bulk_writer)
             await doc.save_changes(bulk_writer=bulk_writer)
 
     assert len(await DocumentTestModel.find_all().to_list()) == 6
-    assert (
-        len(
-            await DocumentTestModel.find(
-                DocumentTestModel.test_int == 100
-            ).to_list()
-        )
-        == 1
-    )
+    assert len(await DocumentTestModel.find(DocumentTestModel.test_int == 100).to_list()) == 1
 
 
 async def test_delete(documents):
@@ -95,12 +59,10 @@ async def test_delete(documents):
     doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
     async with BulkWriter() as bulk_writer:
         await doc.delete(bulk_writer=bulk_writer)
-        await DocumentTestModel.find_one(
-            DocumentTestModel.test_int == 1
-        ).delete(bulk_writer=bulk_writer)
-        await DocumentTestModel.find(DocumentTestModel.test_int < 4).delete(
+        await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).delete(
             bulk_writer=bulk_writer
         )
+        await DocumentTestModel.find(DocumentTestModel.test_int < 4).delete(bulk_writer=bulk_writer)
 
     assert len(await DocumentTestModel.find_all().to_list()) == 1
 
@@ -114,36 +76,25 @@ async def test_replace(documents, document_not_inserted):
 
         document_not_inserted.test_int = 100
 
-        await DocumentTestModel.find_one(
-            DocumentTestModel.test_int == 1
-        ).replace_one(document_not_inserted, bulk_writer=bulk_writer)
+        await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).replace_one(
+            document_not_inserted, bulk_writer=bulk_writer
+        )
 
     assert len(await DocumentTestModel.find_all().to_list()) == 5
-    assert (
-        len(
-            await DocumentTestModel.find(
-                DocumentTestModel.test_int == 100
-            ).to_list()
-        )
-        == 2
-    )
+    assert len(await DocumentTestModel.find(DocumentTestModel.test_int == 100).to_list()) == 2
 
 
 async def test_internal_error(document):
     with pytest.raises(BulkWriteError):
         async with BulkWriter() as bulk_writer:
-            await DocumentTestModel.insert_one(
-                document, bulk_writer=bulk_writer
-            )
+            await DocumentTestModel.insert_one(document, bulk_writer=bulk_writer)
 
 
 async def test_native_upsert_found(documents, document_not_inserted):
     await documents(5)
     document_not_inserted.test_int = -1000
     async with BulkWriter() as bulk_writer:
-        await DocumentTestModel.find_one(
-            DocumentTestModel.test_int == 1
-        ).update_one(
+        await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).update_one(
             {
                 "$addToSet": {
                     "test_list": {
@@ -168,9 +119,7 @@ async def test_native_upsert_not_found(documents, document_not_inserted):
     await documents(5)
     document_not_inserted.test_int = -1000
     async with BulkWriter() as bulk_writer:
-        await DocumentTestModel.find_one(
-            DocumentTestModel.test_int == -1000
-        ).update_one(
+        await DocumentTestModel.find_one(DocumentTestModel.test_int == -1000).update_one(
             {
                 "$addToSet": {
                     "test_list": {
@@ -192,23 +141,15 @@ async def test_native_upsert_not_found(documents, document_not_inserted):
 
 async def test_different_models_same_collection():
     async with BulkWriter() as bulk_writer:
-        await DocumentMultiModelOne.insert_one(
-            DocumentMultiModelOne(), bulk_writer=bulk_writer
-        )
-        await DocumentMultiModelTwo.insert_one(
-            DocumentMultiModelTwo(), bulk_writer=bulk_writer
-        )
+        await DocumentMultiModelOne.insert_one(DocumentMultiModelOne(), bulk_writer=bulk_writer)
+        await DocumentMultiModelTwo.insert_one(DocumentMultiModelTwo(), bulk_writer=bulk_writer)
     assert len(await DocumentUnion.find(with_children=True).to_list()) == 2
 
 
 async def test_empty_operations():
     bulk = BulkWriter()
-    await DocumentMultiModelOne.insert_one(
-        DocumentMultiModelOne(), bulk_writer=bulk
-    )
-    await DocumentMultiModelOne.insert_one(
-        DocumentMultiModelOne(), bulk_writer=bulk
-    )
+    await DocumentMultiModelOne.insert_one(DocumentMultiModelOne(), bulk_writer=bulk)
+    await DocumentMultiModelOne.insert_one(DocumentMultiModelOne(), bulk_writer=bulk)
     assert len(bulk.operations) == 2
     bulk.operations = []
     bulk_result = await bulk.commit()
@@ -225,16 +166,12 @@ async def test_ordered_bulk(documents):
         async with BulkWriter(ordered=True) as bulk_writer:
             doc1 = DocumentMultiModelOne()
             doc1.id = doc.id
-            await DocumentMultiModelOne.insert_one(
-                doc1, bulk_writer=bulk_writer
-            )
-            await DocumentMultiModelOne.insert_one(
-                DocumentMultiModelOne(), bulk_writer=bulk_writer
-            )
+            await DocumentMultiModelOne.insert_one(doc1, bulk_writer=bulk_writer)
+            await DocumentMultiModelOne.insert_one(DocumentMultiModelOne(), bulk_writer=bulk_writer)
 
     assert len(await DocumentMultiModelOne.find_all().to_list()) == 1
 
 
-async def test_bulk_writer():
+def test_bulk_writer():
     assert isinstance(DocumentMultiModelOne.bulk_writer(), BulkWriter)
     assert isinstance(DocumentUnion.bulk_writer(), BulkWriter)

--- a/tests/odm/documents/test_create.py
+++ b/tests/odm/documents/test_create.py
@@ -36,9 +36,7 @@ async def test_create_twice(document_not_inserted):
 
 
 async def test_insert_one_with_session(document_not_inserted, session):
-    result = await DocumentTestModel.insert_one(
-        document_not_inserted, session=session
-    )
+    result = await DocumentTestModel.insert_one(document_not_inserted, session=session)
     document = await DocumentTestModel.get(result.id, session=session)
     assert document is not None
     assert document.test_int == document_not_inserted.test_int
@@ -47,9 +45,7 @@ async def test_insert_one_with_session(document_not_inserted, session):
 
 
 async def test_insert_many_with_session(documents_not_inserted, session):
-    await DocumentTestModel.insert_many(
-        documents_not_inserted(10), session=session
-    )
+    await DocumentTestModel.insert_many(documents_not_inserted(10), session=session)
     documents = await DocumentTestModel.find_all(session=session).to_list()
     assert len(documents) == 10
 
@@ -71,11 +67,7 @@ async def test_insert_keep_nulls_false():
     assert new_doc.m.s is None
     assert new_doc.o is None
 
-    raw_data = (
-        await DocumentWithKeepNullsFalse.get_motor_collection().find_one(
-            {"_id": doc.id}
-        )
-    )
+    raw_data = await DocumentWithKeepNullsFalse.get_motor_collection().find_one({"_id": doc.id})
     assert raw_data == {
         "_id": doc.id,
         "m": {"i": 10},
@@ -100,19 +92,15 @@ async def test_insert_many_keep_nulls_false():
     assert new_docs[1].m.s is None
     assert new_docs[1].o is None
 
-    raw_data = (
-        await DocumentWithKeepNullsFalse.get_motor_collection().find_one(
-            {"_id": new_docs[0].id}
-        )
+    raw_data = await DocumentWithKeepNullsFalse.get_motor_collection().find_one(
+        {"_id": new_docs[0].id}
     )
     assert raw_data == {
         "_id": new_docs[0].id,
         "m": {"i": 10},
     }
-    raw_data = (
-        await DocumentWithKeepNullsFalse.get_motor_collection().find_one(
-            {"_id": new_docs[1].id}
-        )
+    raw_data = await DocumentWithKeepNullsFalse.get_motor_collection().find_one(
+        {"_id": new_docs[1].id}
     )
     assert raw_data == {
         "_id": new_docs[1].id,

--- a/tests/odm/documents/test_distinct.py
+++ b/tests/odm/documents/test_distinct.py
@@ -24,5 +24,5 @@ async def test_distinct_different_value(documents, document_not_inserted):
     document_not_inserted.test_str = "diff_val"
     await document_not_inserted.insert()
     another_unique_test_strs = await DocumentTestModel.distinct("test_str", {})
-    assert not another_unique_test_strs == expected_result
+    assert another_unique_test_strs != expected_result
     assert another_unique_test_strs == ["cuatro", "diff_val", "dos", "uno"]

--- a/tests/odm/documents/test_find.py
+++ b/tests/odm/documents/test_find.py
@@ -81,21 +81,14 @@ async def test_find_all_sort(documents):
     )
 
     assert result[1].test_int >= result[2].test_int
-    assert (
-        result[3].test_int
-        >= result[4].test_int
-        >= result[5].test_int
-        >= result[6].test_int
-    )
+    assert result[3].test_int >= result[4].test_int >= result[5].test_int >= result[6].test_int
 
 
 async def test_find_many(documents):
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
-    result = await DocumentTestModel.find_many(
-        DocumentTestModel.test_str == "uno"
-    ).to_list()
+    result = await DocumentTestModel.find_many(DocumentTestModel.test_str == "uno").to_list()
     assert len(result) == 4
 
 
@@ -103,9 +96,7 @@ async def test_find_many_limit(documents):
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
-    result = await DocumentTestModel.find_many(
-        {"test_str": "uno"}, limit=2
-    ).to_list()
+    result = await DocumentTestModel.find_many({"test_str": "uno"}, limit=2).to_list()
     assert len(result) == 2
 
 
@@ -113,9 +104,7 @@ async def test_find_many_skip(documents):
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
-    result = await DocumentTestModel.find_many(
-        {"test_str": "uno"}, skip=1
-    ).to_list()
+    result = await DocumentTestModel.find_many({"test_str": "uno"}, skip=1).to_list()
     assert len(result) == 3
 
 
@@ -123,25 +112,13 @@ async def test_find_many_sort(documents):
     await documents(4, "uno", True)
     await documents(2, "dos", True)
     await documents(1, "cuatro", True)
-    result = await DocumentTestModel.find_many(
-        {"test_str": "uno"}, sort="test_int"
-    ).to_list()
-    assert (
-        result[0].test_int
-        <= result[1].test_int
-        <= result[2].test_int
-        <= result[3].test_int
-    )
+    result = await DocumentTestModel.find_many({"test_str": "uno"}, sort="test_int").to_list()
+    assert result[0].test_int <= result[1].test_int <= result[2].test_int <= result[3].test_int
 
     result = await DocumentTestModel.find_many(
         {"test_str": "uno"}, sort=[("test_int", pymongo.DESCENDING)]
     ).to_list()
-    assert (
-        result[0].test_int
-        >= result[1].test_int
-        >= result[2].test_int
-        >= result[3].test_int
-    )
+    assert result[0].test_int >= result[1].test_int >= result[2].test_int >= result[3].test_int
 
 
 async def test_find_many_not_found(documents):
@@ -163,9 +140,7 @@ async def test_find_one_with_session(documents, session):
 
     expected_doc_id = PydanticObjectId(inserted_one[0])
 
-    new_document = await DocumentTestModel.find_one(
-        {"test_str": "kipasa"}, session=session
-    )
+    new_document = await DocumentTestModel.find_one({"test_str": "kipasa"}, session=session)
     assert new_document.id == expected_doc_id
 
 
@@ -181,7 +156,5 @@ async def test_find_many_with_session(documents, session):
     await documents(4, "uno")
     await documents(2, "dos")
     await documents(1, "cuatro")
-    result = await DocumentTestModel.find_many(
-        {"test_str": "uno"}, session=session
-    ).to_list()
+    result = await DocumentTestModel.find_many({"test_str": "uno"}, session=session).to_list()
     assert len(result) == 4

--- a/tests/odm/documents/test_inheritance.py
+++ b/tests/odm/documents/test_inheritance.py
@@ -19,25 +19,15 @@ class TestInheritance:
         bike_1 = await Bike(color="black", fuel="gasoline").insert()
 
         car_1 = await Car(color="grey", body="sedan", fuel="gasoline").insert()
-        car_2 = await Car(
-            color="white", body="crossover", fuel="diesel"
-        ).insert()
+        car_2 = await Car(color="white", body="crossover", fuel="diesel").insert()
 
-        bus_1 = await Bus(
-            color="white", seats=80, body="bus", fuel="diesel"
-        ).insert()
-        bus_2 = await Bus(
-            color="yellow", seats=26, body="minibus", fuel="diesel"
-        ).insert()
+        bus_1 = await Bus(color="white", seats=80, body="bus", fuel="diesel").insert()
+        bus_2 = await Bus(color="yellow", seats=26, body="minibus", fuel="diesel").insert()
 
-        white_vehicles = await Vehicle.find(
-            Vehicle.color == "white", with_children=True
-        ).to_list()
+        white_vehicles = await Vehicle.find(Vehicle.color == "white", with_children=True).to_list()
 
         cars_only = await Car.find().to_list()
-        cars_and_buses = await Car.find(
-            Car.fuel == "diesel", with_children=True
-        ).to_list()
+        cars_and_buses = await Car.find(Car.fuel == "diesel", with_children=True).to_list()
 
         big_bicycles = await Bicycle.find(Bicycle.wheels > 28).to_list()
 
@@ -78,13 +68,9 @@ class TestInheritance:
 
     async def test_links(self, db):
         car_1 = await Car(color="grey", body="sedan", fuel="gasoline").insert()
-        car_2 = await Car(
-            color="white", body="crossover", fuel="diesel"
-        ).insert()
+        car_2 = await Car(color="white", body="crossover", fuel="diesel").insert()
 
-        bus_1 = await Bus(
-            color="white", seats=80, body="bus", fuel="diesel"
-        ).insert()
+        bus_1 = await Bus(color="white", seats=80, body="bus", fuel="diesel").insert()
 
         owner = await Owner(name="John").insert()
         owner.vehicles = [car_1, car_2, bus_1]

--- a/tests/odm/documents/test_init.py
+++ b/tests/odm/documents/test_init.py
@@ -24,7 +24,7 @@ from tests.odm.models import (
 )
 
 
-async def test_init_collection_was_not_initialized():
+def test_init_collection_was_not_initialized():
     class NewDocument(Document):
         test_str: str
 
@@ -36,13 +36,8 @@ async def test_init_connection_string(settings):
     class NewDocumentCS(Document):
         test_str: str
 
-    await init_beanie(
-        connection_string=settings.mongodb_dsn, document_models=[NewDocumentCS]
-    )
-    assert (
-        NewDocumentCS.get_motor_collection().database.name
-        == settings.mongodb_dsn.split("/")[-1]
-    )
+    await init_beanie(connection_string=settings.mongodb_dsn, document_models=[NewDocumentCS])
+    assert NewDocumentCS.get_motor_collection().database.name == settings.mongodb_dsn.split("/")[-1]
 
 
 async def test_init_wrong_params(settings, db):
@@ -63,7 +58,7 @@ async def test_init_wrong_params(settings, db):
         await init_beanie(connection_string=settings.mongodb_dsn)
 
 
-async def test_collection_with_custom_name():
+def test_collection_with_custom_name():
     collection: AsyncIOMotorCollection = (
         DocumentTestModelWithCustomCollectionName.get_motor_collection()
     )
@@ -71,9 +66,7 @@ async def test_collection_with_custom_name():
 
 
 async def test_simple_index_creation():
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelWithSimpleIndex.get_motor_collection()
-    )
+    collection: AsyncIOMotorCollection = DocumentTestModelWithSimpleIndex.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info["test_int_1"] == {"key": [("test_int", 1)], "v": 2}
     assert index_info["test_str_text"]["key"] == [
@@ -83,9 +76,7 @@ async def test_simple_index_creation():
 
 
 async def test_flagged_index_creation():
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelWithIndexFlags.get_motor_collection()
-    )
+    collection: AsyncIOMotorCollection = DocumentTestModelWithIndexFlags.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info["test_int_1"] == {
         "key": [("test_int", 1)],
@@ -117,9 +108,7 @@ async def test_flagged_index_creation_with_alias():
 
 
 async def test_annotated_index_creation():
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelIndexFlagsAnnotated.get_motor_collection()
-    )
+    collection: AsyncIOMotorCollection = DocumentTestModelIndexFlagsAnnotated.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info["str_index_text"]["key"] == [
         ("_fts", "text"),
@@ -144,9 +133,7 @@ async def test_annotated_index_creation():
 
 
 async def test_complex_index_creation():
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelWithComplexIndex.get_motor_collection()
-    )
+    collection: AsyncIOMotorCollection = DocumentTestModelWithComplexIndex.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info == {
         "_id_": {"key": [("_id", 1)], "v": 2},
@@ -160,12 +147,8 @@ async def test_complex_index_creation():
 
 
 async def test_index_dropping_is_allowed(db):
-    await init_beanie(
-        database=db, document_models=[DocumentTestModelWithComplexIndex]
-    )
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelWithComplexIndex.get_motor_collection()
-    )
+    await init_beanie(database=db, document_models=[DocumentTestModelWithComplexIndex])
+    collection: AsyncIOMotorCollection = DocumentTestModelWithComplexIndex.get_motor_collection()
 
     await init_beanie(
         database=db,
@@ -173,9 +156,7 @@ async def test_index_dropping_is_allowed(db):
         allow_index_dropping=True,
     )
 
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelWithComplexIndex.get_motor_collection()
-    )
+    collection: AsyncIOMotorCollection = DocumentTestModelWithComplexIndex.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info == {
         "_id_": {"key": [("_id", 1)], "v": 2},
@@ -184,18 +165,14 @@ async def test_index_dropping_is_allowed(db):
 
 
 async def test_index_dropping_is_not_allowed(db):
-    await init_beanie(
-        database=db, document_models=[DocumentTestModelWithComplexIndex]
-    )
+    await init_beanie(database=db, document_models=[DocumentTestModelWithComplexIndex])
     await init_beanie(
         database=db,
         document_models=[DocumentTestModelWithDroppedIndex],
         allow_index_dropping=False,
     )
 
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelWithComplexIndex.get_motor_collection()
-    )
+    collection: AsyncIOMotorCollection = DocumentTestModelWithComplexIndex.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info == {
         "_id_": {"key": [("_id", 1)], "v": 2},
@@ -209,17 +186,13 @@ async def test_index_dropping_is_not_allowed(db):
 
 
 async def test_index_dropping_is_not_allowed_as_default(db):
-    await init_beanie(
-        database=db, document_models=[DocumentTestModelWithComplexIndex]
-    )
+    await init_beanie(database=db, document_models=[DocumentTestModelWithComplexIndex])
     await init_beanie(
         database=db,
         document_models=[DocumentTestModelWithDroppedIndex],
     )
 
-    collection: AsyncIOMotorCollection = (
-        DocumentTestModelWithComplexIndex.get_motor_collection()
-    )
+    collection: AsyncIOMotorCollection = DocumentTestModelWithComplexIndex.get_motor_collection()
     index_info = await collection.index_information()
     assert index_info == {
         "_id_": {"key": [("_id", 1)], "v": 2},
@@ -261,7 +234,7 @@ async def test_document_string_import(db):
         )
 
 
-async def test_projection():
+def test_projection():
     projection = get_projection(DocumentTestModel)
     assert projection == {
         "_id": 1,
@@ -301,28 +274,23 @@ async def test_index_recreation(db):
         document_models=[Sample1],
     )
 
-    await init_beanie(
-        database=db, document_models=[Sample2], allow_index_dropping=True
-    )
+    await init_beanie(database=db, document_models=[Sample2], allow_index_dropping=True)
 
     await db.drop_collection("sample")
 
 
 async def test_merge_indexes():
-    assert (
-        await DocumentWithIndexMerging2.get_motor_collection().index_information()
-        == {
-            "_id_": {"key": [("_id", 1)], "v": 2},
-            "s0_1": {"key": [("s0", 1)], "v": 2},
-            "s1_1": {"key": [("s1", 1)], "v": 2},
-            "s2_-1": {"key": [("s2", -1)], "v": 2},
-            "s3_index": {"key": [("s3", -1)], "v": 2},
-            "s4_index": {"key": [("s4", 1)], "v": 2},
-        }
-    )
+    assert await DocumentWithIndexMerging2.get_motor_collection().index_information() == {
+        "_id_": {"key": [("_id", 1)], "v": 2},
+        "s0_1": {"key": [("s0", 1)], "v": 2},
+        "s1_1": {"key": [("s1", 1)], "v": 2},
+        "s2_-1": {"key": [("s2", -1)], "v": 2},
+        "s3_index": {"key": [("s3", -1)], "v": 2},
+        "s4_index": {"key": [("s4", 1)], "v": 2},
+    }
 
 
-async def test_custom_init():
+def test_custom_init():
     assert DocumentWithCustomInit.s == "TEST2"
 
 
@@ -353,13 +321,10 @@ async def test_init_document_with_union_type_expression_optional_back_link(db):
         ],
     )
 
-    assert (
-        DocumentWithUnionTypeExpressionOptionalBackLink.get_link_fields().keys()
-        == {
-            "back_link_list",
-            "back_link",
-        }
-    )
+    assert DocumentWithUnionTypeExpressionOptionalBackLink.get_link_fields().keys() == {
+        "back_link_list",
+        "back_link",
+    }
 
 
 async def test_init_document_can_inhert_and_extend_settings(db):

--- a/tests/odm/documents/test_inspect.py
+++ b/tests/odm/documents/test_inspect.py
@@ -14,10 +14,7 @@ async def test_inspect_fail(documents):
     result = await DocumentTestModelFailInspection.inspect_collection()
     assert result.status == InspectionStatuses.FAIL
     assert len(result.errors) == 10
-    assert (
-        "1 validation error for DocumentTestModelFailInspection"
-        in result.errors[0].error
-    )
+    assert "1 validation error for DocumentTestModelFailInspection" in result.errors[0].error
 
 
 async def test_inspect_ok_with_session(documents, session):

--- a/tests/odm/documents/test_pydantic_extras.py
+++ b/tests/odm/documents/test_pydantic_extras.py
@@ -28,7 +28,7 @@ async def test_pydantic_extras_kw():
     assert loaded_doc.extra_value == "foo"
 
 
-async def test_fail_with_no_extras():
+def test_fail_with_no_extras():
     doc = DocumentWithPydanticConfig(num_1=2)
     with pytest.raises(ValueError):
         doc.extra_value = "foo"

--- a/tests/odm/documents/test_revision.py
+++ b/tests/odm/documents/test_revision.py
@@ -21,7 +21,7 @@ async def test_replace():
     doc.num_2 = 3
     await doc.replace()
 
-    for i in range(5):
+    for _ in range(5):
         found_doc = await DocumentWithRevisionTurnedOn.get(doc.id)
         found_doc.num_1 += 1
         await found_doc.replace()
@@ -43,7 +43,7 @@ async def test_update():
     await doc.update(Inc({DocumentWithRevisionTurnedOn.num_1: 1}))
     await doc.update(Inc({DocumentWithRevisionTurnedOn.num_1: 1}))
 
-    for i in range(5):
+    for _ in range(5):
         found_doc = await DocumentWithRevisionTurnedOn.get(doc.id)
         await found_doc.update(Inc({DocumentWithRevisionTurnedOn.num_1: 1}))
 
@@ -51,9 +51,7 @@ async def test_update():
     with pytest.raises(RevisionIdWasChanged):
         await doc.update(Inc({DocumentWithRevisionTurnedOn.num_1: 1}))
 
-    await doc.update(
-        Inc({DocumentWithRevisionTurnedOn.num_1: 1}), ignore_revision=True
-    )
+    await doc.update(Inc({DocumentWithRevisionTurnedOn.num_1: 1}), ignore_revision=True)
     await doc.update(Inc({DocumentWithRevisionTurnedOn.num_1: 1}))
 
 
@@ -67,7 +65,7 @@ async def test_save_changes():
     doc.num_2 = 3
     await doc.save_changes()
 
-    for i in range(5):
+    for _ in range(5):
         found_doc = await DocumentWithRevisionTurnedOn.get(doc.id)
         found_doc.num_1 += 1
         await found_doc.save_changes()
@@ -90,7 +88,7 @@ async def test_save():
     doc.num_2 = 3
     await doc.save()
 
-    for i in range(5):
+    for _ in range(5):
         found_doc = await DocumentWithRevisionTurnedOn.get(doc.id)
         found_doc.num_1 += 1
         await found_doc.save()
@@ -120,7 +118,7 @@ async def test_update_bulk_writer():
 
     doc = await DocumentWithRevisionTurnedOn.get(doc.id)
 
-    for i in range(5):
+    for _ in range(5):
         found_doc = await DocumentWithRevisionTurnedOn.get(doc.id)
         found_doc.num_1 += 1
         async with BulkWriter() as bulk_writer:

--- a/tests/odm/documents/test_soft_delete.py
+++ b/tests/odm/documents/test_soft_delete.py
@@ -22,9 +22,7 @@ async def test_get_item(document_soft_delete_not_inserted):
     assert document is None
 
     # check document exist in trashed
-    results = (
-        await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
-    )
+    results = await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
     assert len(results) == 1
 
 
@@ -64,9 +62,7 @@ async def test_find(documents_soft_delete_not_inserted):
     assert inserted_docs[0].id not in founded_documents_id
 
     # check in trashed items
-    results = (
-        await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
-    )
+    results = await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
     assert len(results) == 3
 
 
@@ -89,9 +85,7 @@ async def test_find_many(documents_soft_delete_not_inserted):
     assert results[0].id == item_2.id
 
     # check in trashed items
-    results = (
-        await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
-    )
+    results = await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
     assert len(results) == 2
 
 
@@ -104,7 +98,5 @@ async def test_hard_delete(document_soft_delete_not_inserted):
     assert len(results) == 0
 
     # check in trashed
-    results = (
-        await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
-    )
+    results = await DocumentTestModelWithSoftDelete.find_many_in_all().to_list()
     assert len(results) == 0

--- a/tests/odm/documents/test_update.py
+++ b/tests/odm/documents/test_update.py
@@ -29,26 +29,20 @@ from tests.odm.models import (
 
 async def test_replace_many(documents):
     await documents(10, "foo")
-    created_documents = await DocumentTestModel.find_many(
-        {"test_str": "foo"}
-    ).to_list()
+    created_documents = await DocumentTestModel.find_many({"test_str": "foo"}).to_list()
     to_replace = []
     for document in created_documents[:5]:
         document.test_str = "REPLACED_VALUE"
         to_replace.append(document)
     await DocumentTestModel.replace_many(to_replace)
 
-    replaced_documetns = await DocumentTestModel.find_many(
-        {"test_str": "REPLACED_VALUE"}
-    ).to_list()
+    replaced_documetns = await DocumentTestModel.find_many({"test_str": "REPLACED_VALUE"}).to_list()
     assert len(replaced_documetns) == 5
 
 
 async def test_replace_many_not_all_the_docs_found(documents):
     await documents(10, "foo")
-    created_documents = await DocumentTestModel.find_many(
-        {"test_str": "foo"}
-    ).to_list()
+    created_documents = await DocumentTestModel.find_many({"test_str": "foo"}).to_list()
     to_replace = []
     created_documents[0].id = PydanticObjectId()
     for document in created_documents[:5]:
@@ -98,10 +92,7 @@ async def test_save(document):
 
 async def test_save_not_saved(document_not_inserted):
     await document_not_inserted.save()
-    assert (
-        hasattr(document_not_inserted, "id")
-        and document_not_inserted.id is not None
-    )
+    assert hasattr(document_not_inserted, "id") and document_not_inserted.id is not None
     from_db = await DocumentTestModel.get(document_not_inserted.id)
     assert from_db == document_not_inserted
 
@@ -109,10 +100,7 @@ async def test_save_not_saved(document_not_inserted):
 async def test_save_not_found(document_not_inserted):
     document_not_inserted.id = PydanticObjectId()
     await document_not_inserted.save()
-    assert (
-        hasattr(document_not_inserted, "id")
-        and document_not_inserted.id is not None
-    )
+    assert hasattr(document_not_inserted, "id") and document_not_inserted.id is not None
     from_db = await DocumentTestModel.get(document_not_inserted.id)
     assert from_db == document_not_inserted
 
@@ -121,9 +109,9 @@ async def test_save_not_found(document_not_inserted):
 
 
 async def test_update_one(document):
-    await DocumentTestModel.find_one(
-        {"_id": document.id, "test_list.test_str": "foo"}
-    ).update({"$set": {"test_list.$.test_str": "foo_foo"}})
+    await DocumentTestModel.find_one({"_id": document.id, "test_list.test_str": "foo"}).update(
+        {"$set": {"test_list.$.test_str": "foo_foo"}}
+    )
     new_document = await DocumentTestModel.get(document.id)
     assert new_document.test_list[0].test_str == "foo_foo"
 
@@ -139,16 +127,10 @@ async def test_update_one_set_extra_field():
 async def test_update_many(documents):
     await documents(10, "foo")
     await documents(7, "bar")
-    await DocumentTestModel.find_many({"test_str": "foo"}).update(
-        {"$set": {"test_str": "bar"}}
-    )
-    bar_documetns = await DocumentTestModel.find_many(
-        {"test_str": "bar"}
-    ).to_list()
+    await DocumentTestModel.find_many({"test_str": "foo"}).update({"$set": {"test_str": "bar"}})
+    bar_documetns = await DocumentTestModel.find_many({"test_str": "bar"}).to_list()
     assert len(bar_documetns) == 17
-    foo_documetns = await DocumentTestModel.find_many(
-        {"test_str": "foo"}
-    ).to_list()
+    foo_documetns = await DocumentTestModel.find_many({"test_str": "foo"}).to_list()
     assert len(foo_documetns) == 0
 
 
@@ -158,17 +140,11 @@ async def test_update_all(documents):
     await DocumentTestModel.update_all(
         {"$set": {"test_str": "smth_else"}},
     )
-    bar_documetns = await DocumentTestModel.find_many(
-        {"test_str": "bar"}
-    ).to_list()
+    bar_documetns = await DocumentTestModel.find_many({"test_str": "bar"}).to_list()
     assert len(bar_documetns) == 0
-    foo_documetns = await DocumentTestModel.find_many(
-        {"test_str": "foo"}
-    ).to_list()
+    foo_documetns = await DocumentTestModel.find_many({"test_str": "foo"}).to_list()
     assert len(foo_documetns) == 0
-    smth_else_documetns = await DocumentTestModel.find_many(
-        {"test_str": "smth_else"}
-    ).to_list()
+    smth_else_documetns = await DocumentTestModel.find_many({"test_str": "smth_else"}).to_list()
     assert len(smth_else_documetns) == 17
 
 
@@ -186,11 +162,7 @@ async def test_save_keep_nulls_false():
     assert from_db.o is None
     assert from_db.m.s is None
 
-    raw_data = (
-        await DocumentWithKeepNullsFalse.get_motor_collection().find_one(
-            {"_id": doc.id}
-        )
-    )
+    raw_data = await DocumentWithKeepNullsFalse.get_motor_collection().find_one({"_id": doc.id})
     assert raw_data == {"_id": doc.id, "m": {"i": 10}}
 
 
@@ -209,11 +181,7 @@ async def test_save_changes_keep_nulls_false():
     assert from_db.o is None
     assert from_db.m.s is None
 
-    raw_data = (
-        await DocumentWithKeepNullsFalse.get_motor_collection().find_one(
-            {"_id": doc.id}
-        )
-    )
+    raw_data = await DocumentWithKeepNullsFalse.get_motor_collection().find_one({"_id": doc.id})
     assert raw_data == {"_id": doc.id, "m": {"i": 10}}
 
 
@@ -313,9 +281,7 @@ async def test_update_list():
 
 
 async def test_update_using_pipeline(preset_documents):
-    await Sample.all().update(
-        [{"$set": {"integer": 10000}}, {"$set": {"string": "TEST3"}}]
-    )
+    await Sample.all().update([{"$set": {"integer": 10000}}, {"$set": {"string": "TEST3"}}])
     all_docs = await Sample.find_many({}).to_list()
     for doc in all_docs:
         assert doc.integer == 10000

--- a/tests/odm/documents/test_validation_on_save.py
+++ b/tests/odm/documents/test_validation_on_save.py
@@ -50,9 +50,7 @@ async def test_validate_on_save_keep_the_id_type():
         doc = doc.copy(update=update.dict(exclude_unset=True))
     doc.num_2 = 1000
     await doc.save()
-    in_db = await DocumentWithValidationOnSave.get_motor_collection().find_one(
-        {"_id": doc.id}
-    )
+    in_db = await DocumentWithValidationOnSave.get_motor_collection().find_one({"_id": doc.id})
     assert isinstance(in_db["related"], ObjectId)
     new_doc = await DocumentWithValidationOnSave.get(doc.id)
     assert isinstance(new_doc.related, PydanticObjectId)

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -11,15 +11,11 @@ from ipaddress import (
 )
 from pathlib import Path
 from typing import (
+    Annotated,
     Any,
     Callable,
     ClassVar,
-    Dict,
-    List,
     Optional,
-    Set,
-    Tuple,
-    Type,
     Union,
 )
 from uuid import UUID, uuid4
@@ -39,7 +35,6 @@ from pydantic import (
 )
 from pydantic_core import core_schema
 from pymongo import IndexModel
-from typing_extensions import Annotated
 
 from beanie import (
     DecimalAnnotation,
@@ -97,14 +92,12 @@ class Color:
         @classmethod
         def __get_pydantic_core_schema__(
             cls,
-            _source_type: Type[Any],
+            _source_type: type[Any],
             _handler: Callable[[Any], core_schema.CoreSchema],
         ) -> core_schema.CoreSchema:
             return core_schema.json_or_python_schema(
                 json_schema=core_schema.str_schema(),
-                python_schema=core_schema.no_info_plain_validator_function(
-                    cls._validate
-                ),
+                python_schema=core_schema.no_info_plain_validator_function(cls._validate),
             )
 
     else:
@@ -135,7 +128,7 @@ class Nested(BaseModel):
 
 class GeoObject(BaseModel):
     type: str = "Point"
-    coordinates: Tuple[float, float]
+    coordinates: tuple[float, float]
 
 
 class Sample(Document):
@@ -165,7 +158,7 @@ class DocumentTestModel(Document):
     test_int: int
     test_doc: SubDocument
     test_str: str
-    test_list: List[SubDocument] = Field(exclude=True)
+    test_list: list[SubDocument] = Field(exclude=True)
 
     class Settings:
         use_cache = True
@@ -186,7 +179,7 @@ class DocumentTestModelWithLink(Document):
 
 class DocumentTestModelWithCustomCollectionName(Document):
     test_int: int
-    test_list: List[SubDocument]
+    test_list: list[SubDocument]
     test_str: str
 
     class Settings:
@@ -196,7 +189,7 @@ class DocumentTestModelWithCustomCollectionName(Document):
 
 class DocumentTestModelWithSimpleIndex(Document):
     test_int: Indexed(int)
-    test_list: List[SubDocument]
+    test_list: list[SubDocument]
     test_str: Indexed(str, index_type=pymongo.TEXT)
 
 
@@ -207,9 +200,7 @@ class DocumentTestModelWithIndexFlags(Document):
 
 class DocumentTestModelWithIndexFlagsAliases(Document):
     test_int: Indexed(int, sparse=True) = Field(alias="testInt")
-    test_str: Indexed(str, index_type=pymongo.DESCENDING, unique=True) = Field(
-        alias="testStr"
-    )
+    test_str: Indexed(str, index_type=pymongo.DESCENDING, unique=True) = Field(alias="testStr")
 
 
 class DocumentTestModelIndexFlagsAnnotated(Document):
@@ -225,7 +216,7 @@ class DocumentTestModelIndexFlagsAnnotated(Document):
 
 class DocumentTestModelWithComplexIndex(Document):
     test_int: int
-    test_list: List[SubDocument]
+    test_list: list[SubDocument]
     test_str: str
 
     class Settings:
@@ -245,7 +236,7 @@ class DocumentTestModelWithComplexIndex(Document):
 
 class DocumentTestModelWithDroppedIndex(Document):
     test_int: int
-    test_list: List[SubDocument]
+    test_list: list[SubDocument]
     test_str: str
 
     class Settings:
@@ -268,9 +259,9 @@ class DocumentTestModelFailInspection(Document):
 
 class DocumentWithDeprecatedHiddenField(Document):
     if IS_PYDANTIC_V2:
-        test_hidden: List[str] = Field(json_schema_extra={"hidden": True})
+        test_hidden: list[str] = Field(json_schema_extra={"hidden": True})
     else:
-        test_hidden: List[str] = Field(hidden=True)
+        test_hidden: list[str] = Field(hidden=True)
 
 
 class DocumentWithCustomIdUUID(Document):
@@ -295,8 +286,8 @@ class DocumentWithCustomFiledsTypes(Document):
     ipv6interface: IPv6Interface
     ipv6network: IPv6Network
     timedelta: datetime.timedelta
-    set_type: Set[str]
-    tuple_type: Tuple[int, str]
+    set_type: set[str]
+    tuple_type: tuple[int, str]
     path: Path
 
     class Settings:
@@ -427,7 +418,7 @@ class InternalDoc(BaseModel):
     _private_field: str = PrivateAttr(default="TEST_PRIVATE")
     num: int = 100
     string: str = "test"
-    lst: List[int] = [1, 2, 3, 4, 5]
+    lst: list[int] = [1, 2, 3, 4, 5]
 
     def change_private(self):
         self._private_field = "PRIVATE_CHANGED"
@@ -555,7 +546,7 @@ class WindowWithValidationOnSave(Document):
 class Door(Document):
     t: int = 10
     window: Optional[Link[Window]] = None
-    locks: Optional[List[Link[Lock]]] = None
+    locks: Optional[list[Link[Lock]]] = None
 
 
 class Roof(Document):
@@ -563,10 +554,10 @@ class Roof(Document):
 
 
 class House(Document):
-    windows: List[Link[Window]]
+    windows: list[Link[Window]]
     door: Link[Door]
     roof: Optional[Link[Roof]] = None
-    yards: Optional[List[Link[Yard]]] = None
+    yards: Optional[list[Link[Yard]]] = None
     height: Indexed(int) = 2
     name: Indexed(str) = Field(exclude=True)
 
@@ -666,7 +657,7 @@ class WindowWithRevision(Document):
 
 
 class HouseWithRevision(Document):
-    windows: List[Link[WindowWithRevision]]
+    windows: list[Link[WindowWithRevision]]
 
     class Settings:
         use_revision = True
@@ -719,7 +710,7 @@ class Bus(Car, Fuelled):
 
 class Owner(Document):
     name: str
-    vehicles: List[Link[Vehicle]] = []
+    vehicles: list[Link[Vehicle]] = []
 
 
 class MixinNonRoot(BaseModel):
@@ -744,14 +735,14 @@ class Child(BaseModel):
 
 
 class SampleWithMutableObjects(Document):
-    d: Dict[str, Child]
-    lst: List[Child]
+    d: dict[str, Child]
+    lst: list[Child]
 
 
 class SampleLazyParsing(Document):
     i: int
     s: str
-    lst: List[int] = Field(
+    lst: list[int] = Field(
         [],
     )
 
@@ -792,9 +783,7 @@ class BDocument(RootDocument):
 
 class StateAndDecimalFieldModel(Document):
     amt: DecimalAnnotation
-    other_amt: DecimalAnnotation = Field(
-        decimal_places=1, multiple_of=0.5, default=0
-    )
+    other_amt: DecimalAnnotation = Field(decimal_places=1, multiple_of=0.5, default=0)
 
     class Settings:
         name = "amounts"
@@ -863,9 +852,7 @@ class DocWithCollectionInnerClass(Document):
 
 class DocumentWithDecimalField(Document):
     amt: DecimalAnnotation
-    other_amt: DecimalAnnotation = Field(
-        decimal_places=1, multiple_of=0.5, default=0
-    )
+    other_amt: DecimalAnnotation = Field(decimal_places=1, multiple_of=0.5, default=0)
 
     if IS_PYDANTIC_V2:
         model_config = ConfigDict(
@@ -881,9 +868,7 @@ class DocumentWithDecimalField(Document):
         use_revision = True
         use_state_management = True
         indexes = [
-            pymongo.IndexModel(
-                keys=[("amt", pymongo.ASCENDING)], name="amt_ascending"
-            ),
+            pymongo.IndexModel(keys=[("amt", pymongo.ASCENDING)], name="amt_ascending"),
             pymongo.IndexModel(
                 keys=[("other_amt", pymongo.DESCENDING)],
                 name="other_amt_descending",
@@ -912,7 +897,7 @@ class ReleaseElemMatch(BaseModel):
 
 
 class PackageElemMatch(Document):
-    releases: List[ReleaseElemMatch] = []
+    releases: list[ReleaseElemMatch] = []
 
 
 class DocumentWithLink(Document):
@@ -941,56 +926,48 @@ class DocumentWithOptionalBackLink(Document):
             json_schema_extra={"original_field": "link"},
         )
     else:
-        back_link: Optional[BackLink[DocumentWithLink]] = Field(
-            original_field="link"
-        )
+        back_link: Optional[BackLink[DocumentWithLink]] = Field(original_field="link")
     i: int = 1
 
 
 class DocumentWithListLink(Document):
-    link: List[Link["DocumentWithListBackLink"]]
+    link: list[Link["DocumentWithListBackLink"]]
     s: str = "TEST"
 
 
 class DocumentWithListBackLink(Document):
     if IS_PYDANTIC_V2:
-        back_link: List[BackLink[DocumentWithListLink]] = Field(
+        back_link: list[BackLink[DocumentWithListLink]] = Field(
             json_schema_extra={"original_field": "link"},
         )
     else:
-        back_link: List[BackLink[DocumentWithListLink]] = Field(
-            original_field="link"
-        )
+        back_link: list[BackLink[DocumentWithListLink]] = Field(original_field="link")
     i: int = 1
 
 
 class DocumentWithOptionalListBackLink(Document):
     if IS_PYDANTIC_V2:
-        back_link: Optional[List[BackLink[DocumentWithListLink]]] = Field(
+        back_link: Optional[list[BackLink[DocumentWithListLink]]] = Field(
             json_schema_extra={"original_field": "link"},
         )
     else:
-        back_link: Optional[List[BackLink[DocumentWithListLink]]] = Field(
-            original_field="link"
-        )
+        back_link: Optional[list[BackLink[DocumentWithListLink]]] = Field(original_field="link")
     i: int = 1
 
 
 class DocumentWithUnionTypeExpressionOptionalBackLink(Document):
     if IS_PYDANTIC_V2:
-        back_link_list: type_union(
-            List[BackLink[DocumentWithListLink]], None
-        ) = Field(json_schema_extra={"original_field": "link"})
+        back_link_list: type_union(list[BackLink[DocumentWithListLink]], None) = Field(
+            json_schema_extra={"original_field": "link"}
+        )
         back_link: type_union(BackLink[DocumentWithLink], None) = Field(
             json_schema_extra={"original_field": "link"}
         )
     else:
-        back_link_list: type_union(
-            List[BackLink[DocumentWithListLink]], None
-        ) = Field(original_field="link")
-        back_link: type_union(BackLink[DocumentWithLink], None) = Field(
+        back_link_list: type_union(list[BackLink[DocumentWithListLink]], None) = Field(
             original_field="link"
         )
+        back_link: type_union(BackLink[DocumentWithLink], None) = Field(original_field="link")
     i: int = 1
 
 
@@ -999,7 +976,7 @@ class DocumentToBeLinked(Document):
 
 
 class DocumentWithListOfLinks(Document):
-    links: List[Link[DocumentToBeLinked]]
+    links: list[Link[DocumentToBeLinked]]
     s: str = "TEST"
 
 
@@ -1069,7 +1046,7 @@ class DocumentWithTextIndexAndLink(Document):
 
 
 class DocumentWithList(Document):
-    list_values: List[str]
+    list_values: list[str]
 
 
 class DocumentWithBsonBinaryField(Document):
@@ -1077,9 +1054,9 @@ class DocumentWithBsonBinaryField(Document):
 
 
 if IS_PYDANTIC_V2:
-    Pets = RootModel[List[str]]
+    Pets = RootModel[list[str]]
 else:
-    Pets = List[str]
+    Pets = list[str]
 
 
 class DocumentWithRootModelAsAField(Document):
@@ -1101,7 +1078,7 @@ class DocumentWithHttpUrlField(Document):
 
 
 class DocumentWithComplexDictKey(Document):
-    dict_field: Dict[UUID, datetime.datetime]
+    dict_field: dict[UUID, datetime.datetime]
 
 
 class DocumentWithIndexedObjectId(Document):
@@ -1113,11 +1090,9 @@ class DocumentWithIndexedObjectId(Document):
 class DocumentToTestSync(Document):
     s: str = "TEST"
     i: int = 1
-    n: Nested = Nested(
-        integer=1, option_1=Option1(s="test"), union=Option1(s="test")
-    )
+    n: Nested = Nested(integer=1, option_1=Option1(s="test"), union=Option1(s="test"))
     o: Optional[Option2] = None
-    d: Dict[str, Any] = {}
+    d: dict[str, Any] = {}
 
     class Settings:
         use_state_management = True
@@ -1137,9 +1112,7 @@ class DocumentWithBackLinkForNesting(Document):
             json_schema_extra={"original_field": "link"},
         )
     else:
-        back_link: BackLink[DocumentWithLinkForNesting] = Field(
-            original_field="link"
-        )
+        back_link: BackLink[DocumentWithLinkForNesting] = Field(original_field="link")
     i: int
 
     class Settings:
@@ -1159,7 +1132,7 @@ class DictEnum(str, Enum):
 
 
 class DocumentWithEnumKeysDict(Document):
-    color: Dict[DictEnum, str]
+    color: dict[DictEnum, str]
 
 
 class BsonRegexDoc(Document):

--- a/tests/odm/operators/find/test_array.py
+++ b/tests/odm/operators/find/test_array.py
@@ -2,27 +2,21 @@ from beanie.odm.operators.find.array import All, ElemMatch, Size
 from tests.odm.models import PackageElemMatch, Sample
 
 
-async def test_all():
+def test_all():
     q = All(Sample.integer, [1, 2, 3])
     assert q == {"integer": {"$all": [1, 2, 3]}}
 
 
-async def test_elem_match():
+def test_elem_match():
     q = ElemMatch(Sample.integer, {"a": "b"})
     assert q == {"integer": {"$elemMatch": {"a": "b"}}}
 
 
-async def test_size():
+def test_size():
     q = Size(Sample.integer, 4)
     assert q == {"integer": {"$size": 4}}
 
 
-async def test_elem_match_nested():
-    q = ElemMatch(
-        PackageElemMatch.releases, major_ver=7, minor_ver=1, build_ver=0
-    )
-    assert q == {
-        "releases": {
-            "$elemMatch": {"major_ver": 7, "minor_ver": 1, "build_ver": 0}
-        }
-    }
+def test_elem_match_nested():
+    q = ElemMatch(PackageElemMatch.releases, major_ver=7, minor_ver=1, build_ver=0)
+    assert q == {"releases": {"$elemMatch": {"major_ver": 7, "minor_ver": 1, "build_ver": 0}}}

--- a/tests/odm/operators/find/test_bitwise.py
+++ b/tests/odm/operators/find/test_bitwise.py
@@ -7,21 +7,21 @@ from beanie.odm.operators.find.bitwise import (
 from tests.odm.models import Sample
 
 
-async def test_bits_all_clear():
+def test_bits_all_clear():
     q = BitsAllClear(Sample.integer, "smth")
     assert q == {"integer": {"$bitsAllClear": "smth"}}
 
 
-async def test_bits_all_set():
+def test_bits_all_set():
     q = BitsAllSet(Sample.integer, "smth")
     assert q == {"integer": {"$bitsAllSet": "smth"}}
 
 
-async def test_any_clear():
+def test_any_clear():
     q = BitsAnyClear(Sample.integer, "smth")
     assert q == {"integer": {"$bitsAnyClear": "smth"}}
 
 
-async def test_any_set():
+def test_any_set():
     q = BitsAnySet(Sample.integer, "smth")
     assert q == {"integer": {"$bitsAnySet": "smth"}}

--- a/tests/odm/operators/find/test_comparison.py
+++ b/tests/odm/operators/find/test_comparison.py
@@ -11,7 +11,7 @@ from beanie.odm.operators.find.comparison import (
 from tests.odm.models import Sample
 
 
-async def test_eq():
+def test_eq():
     q = Sample.integer == 1
     assert q == {"integer": 1}
 
@@ -22,7 +22,7 @@ async def test_eq():
     assert q == {"integer": 1}
 
 
-async def test_gt():
+def test_gt():
     q = Sample.integer > 1
     assert q == {"integer": {"$gt": 1}}
 
@@ -33,7 +33,7 @@ async def test_gt():
     assert q == {"integer": {"$gt": 1}}
 
 
-async def test_gte():
+def test_gte():
     q = Sample.integer >= 1
     assert q == {"integer": {"$gte": 1}}
 
@@ -44,7 +44,7 @@ async def test_gte():
     assert q == {"integer": {"$gte": 1}}
 
 
-async def test_in():
+def test_in():
     q = In(Sample.integer, [1])
     assert q == {"integer": {"$in": [1]}}
 
@@ -52,7 +52,7 @@ async def test_in():
     assert q == {"integer": {"$in": [1]}}
 
 
-async def test_lt():
+def test_lt():
     q = Sample.integer < 1
     assert q == {"integer": {"$lt": 1}}
 
@@ -63,7 +63,7 @@ async def test_lt():
     assert q == {"integer": {"$lt": 1}}
 
 
-async def test_lte():
+def test_lte():
     q = Sample.integer <= 1
     assert q == {"integer": {"$lte": 1}}
 
@@ -74,7 +74,7 @@ async def test_lte():
     assert q == {"integer": {"$lte": 1}}
 
 
-async def test_ne():
+def test_ne():
     q = Sample.integer != 1
     assert q == {"integer": {"$ne": 1}}
 
@@ -85,7 +85,7 @@ async def test_ne():
     assert q == {"integer": {"$ne": 1}}
 
 
-async def test_nin():
+def test_nin():
     q = NotIn(Sample.integer, [1])
     assert q == {"integer": {"$nin": [1]}}
 

--- a/tests/odm/operators/find/test_element.py
+++ b/tests/odm/operators/find/test_element.py
@@ -2,7 +2,7 @@ from beanie.odm.operators.find.element import Exists, Type
 from tests.odm.models import Sample
 
 
-async def test_exists():
+def test_exists():
     q = Exists(Sample.integer, True)
     assert q == {"integer": {"$exists": True}}
 
@@ -13,6 +13,6 @@ async def test_exists():
     assert q == {"integer": {"$exists": True}}
 
 
-async def test_type():
+def test_type():
     q = Type(Sample.integer, "smth")
     assert q == {"integer": {"$type": "smth"}}

--- a/tests/odm/operators/find/test_evaluation.py
+++ b/tests/odm/operators/find/test_evaluation.py
@@ -9,22 +9,22 @@ from beanie.odm.operators.find.evaluation import (
 from tests.odm.models import Sample
 
 
-async def test_expr():
+def test_expr():
     q = Expr({"a": "B"})
     assert q == {"$expr": {"a": "B"}}
 
 
-async def test_json_schema():
+def test_json_schema():
     q = JsonSchema({"a": "B"})
     assert q == {"$jsonSchema": {"a": "B"}}
 
 
-async def test_mod():
+def test_mod():
     q = Mod(Sample.integer, 3, 2)
     assert q == {"integer": {"$mod": [3, 2]}}
 
 
-async def test_regex():
+def test_regex():
     q = RegEx(Sample.integer, "smth")
     assert q == {"integer": {"$regex": "smth"}}
 
@@ -32,7 +32,7 @@ async def test_regex():
     assert q == {"integer": {"$regex": "smth", "$options": "options"}}
 
 
-async def test_text():
+def test_text():
     q = Text("something")
     assert q == {
         "$text": {
@@ -75,6 +75,6 @@ async def test_text():
     }
 
 
-async def test_where():
+def test_where():
     q = Where("test")
     assert q == {"$where": "test"}

--- a/tests/odm/operators/find/test_geospatial.py
+++ b/tests/odm/operators/find/test_geospatial.py
@@ -8,10 +8,8 @@ from beanie.odm.operators.find.geospatial import (
 from tests.odm.models import Sample
 
 
-async def test_geo_intersects():
-    q = GeoIntersects(
-        Sample.geo, geo_type="Polygon", coordinates=[[1, 1], [2, 2], [3, 3]]
-    )
+def test_geo_intersects():
+    q = GeoIntersects(Sample.geo, geo_type="Polygon", coordinates=[[1, 1], [2, 2], [3, 3]])
     assert q == {
         "geo": {
             "$geoIntersects": {
@@ -24,10 +22,8 @@ async def test_geo_intersects():
     }
 
 
-async def test_geo_within():
-    q = GeoWithin(
-        Sample.geo, geo_type="Polygon", coordinates=[[1, 1], [2, 2], [3, 3]]
-    )
+def test_geo_within():
+    q = GeoWithin(Sample.geo, geo_type="Polygon", coordinates=[[1, 1], [2, 2], [3, 3]])
     assert q == {
         "geo": {
             "$geoWithin": {
@@ -40,20 +36,14 @@ async def test_geo_within():
     }
 
 
-async def test_box():
+def test_box():
     q = Box(Sample.geo, lower_left=[1, 3], upper_right=[2, 4])
     assert q == {"geo": {"$geoWithin": {"$box": [[1, 3], [2, 4]]}}}
 
 
-async def test_near():
+def test_near():
     q = Near(Sample.geo, longitude=1.1, latitude=2.2)
-    assert q == {
-        "geo": {
-            "$near": {
-                "$geometry": {"type": "Point", "coordinates": [1.1, 2.2]}
-            }
-        }
-    }
+    assert q == {"geo": {"$near": {"$geometry": {"type": "Point", "coordinates": [1.1, 2.2]}}}}
 
     q = Near(Sample.geo, longitude=1.1, latitude=2.2, max_distance=1)
     assert q == {
@@ -83,14 +73,10 @@ async def test_near():
     }
 
 
-async def test_near_sphere():
+def test_near_sphere():
     q = NearSphere(Sample.geo, longitude=1.1, latitude=2.2)
     assert q == {
-        "geo": {
-            "$nearSphere": {
-                "$geometry": {"type": "Point", "coordinates": [1.1, 2.2]}
-            }
-        }
+        "geo": {"$nearSphere": {"$geometry": {"type": "Point", "coordinates": [1.1, 2.2]}}}
     }
 
     q = NearSphere(Sample.geo, longitude=1.1, latitude=2.2, max_distance=1)

--- a/tests/odm/operators/find/test_logical.py
+++ b/tests/odm/operators/find/test_logical.py
@@ -4,7 +4,7 @@ from beanie.odm.operators.find.logical import And, Nor, Not, Or
 from tests.odm.models import Sample
 
 
-async def test_and():
+def test_and():
     q = And(Sample.integer == 1)
     assert q == {"integer": 1}
 
@@ -24,7 +24,7 @@ async def test_not(preset_documents):
         await Sample.find(q).to_list()
 
 
-async def test_nor():
+def test_nor():
     q = Nor(Sample.integer == 1)
     assert q == {"$nor": [{"integer": 1}]}
 
@@ -32,7 +32,7 @@ async def test_nor():
     assert q == {"$nor": [{"integer": 1}, {"nested.integer": {"$gt": 3}}]}
 
 
-async def test_or():
+def test_or():
     q = Or(Sample.integer == 1)
     assert q == {"integer": 1}
 

--- a/tests/odm/query/test_aggregate.py
+++ b/tests/odm/query/test_aggregate.py
@@ -9,9 +9,7 @@ from tests.odm.models import DocumentWithTextIndexAndLink, Sample
 
 
 async def test_aggregate(preset_documents):
-    q = Sample.aggregate(
-        [{"$group": {"_id": "$string", "total": {"$sum": "$integer"}}}]
-    )
+    q = Sample.aggregate([{"$group": {"_id": "$string", "total": {"$sum": "$integer"}}}])
     assert q.get_aggregation_pipeline() == [
         {"$group": {"_id": "$string", "total": {"$sum": "$integer"}}}
     ]
@@ -135,7 +133,7 @@ async def test_aggregate_pymongo_kwargs(preset_documents):
         )
 
 
-async def test_clone(preset_documents):
+def test_clone(preset_documents):
     q = Sample.find(Sample.increment >= 4).aggregate(
         [{"$group": {"_id": "$string", "total": {"$sum": "$integer"}}}]
     )
@@ -154,9 +152,7 @@ async def test_clone(preset_documents):
 
 @pytest.mark.parametrize("text_query_count", [0, 1, 2])
 @pytest.mark.parametrize("non_text_query_count", [0, 1, 2])
-async def test_with_text_queries(
-    text_query_count: int, non_text_query_count: int
-):
+def test_with_text_queries(text_query_count: int, non_text_query_count: int):
     text_query = {"$text": {"$search": "text_search"}}
     non_text_query = {"s": "test_string"}
     aggregation_pipeline = [{"$count": "count"}]
@@ -182,9 +178,7 @@ async def test_with_text_queries(
             else {"$match": {"$and": [text_query, text_query]}}
         )
 
-    expected_aggregation_pipeline.extend(
-        construct_lookup_queries(query.document_model)
-    )
+    expected_aggregation_pipeline.extend(construct_lookup_queries(query.document_model))
 
     if non_text_query_count:
         expected_aggregation_pipeline.append(
@@ -195,7 +189,4 @@ async def test_with_text_queries(
 
     expected_aggregation_pipeline.extend(aggregation_pipeline)
 
-    assert (
-        query.build_aggregation_pipeline(*aggregation_pipeline)
-        == expected_aggregation_pipeline
-    )
+    assert query.build_aggregation_pipeline(*aggregation_pipeline) == expected_aggregation_pipeline

--- a/tests/odm/query/test_aggregate_methods.py
+++ b/tests/odm/query/test_aggregate_methods.py
@@ -6,9 +6,7 @@ async def test_sum(preset_documents, session):
 
     assert n == 12
 
-    n = await Sample.find_many(Sample.integer == 1).sum(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).sum(Sample.increment, session=session)
 
     assert n == 12
 
@@ -18,9 +16,7 @@ async def test_sum_without_docs(session):
 
     assert n is None
 
-    n = await Sample.find_many(Sample.integer == 1).sum(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).sum(Sample.increment, session=session)
 
     assert n is None
 
@@ -29,9 +25,7 @@ async def test_avg(preset_documents, session):
     n = await Sample.find_many(Sample.integer == 1).avg(Sample.increment)
 
     assert n == 4
-    n = await Sample.find_many(Sample.integer == 1).avg(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).avg(Sample.increment, session=session)
 
     assert n == 4
 
@@ -40,9 +34,7 @@ async def test_avg_without_docs(session):
     n = await Sample.find_many(Sample.integer == 1).avg(Sample.increment)
 
     assert n is None
-    n = await Sample.find_many(Sample.integer == 1).avg(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).avg(Sample.increment, session=session)
 
     assert n is None
 
@@ -52,9 +44,7 @@ async def test_max(preset_documents, session):
 
     assert n == 5
 
-    n = await Sample.find_many(Sample.integer == 1).max(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).max(Sample.increment, session=session)
 
     assert n == 5
 
@@ -64,9 +54,7 @@ async def test_max_without_docs(session):
 
     assert n is None
 
-    n = await Sample.find_many(Sample.integer == 1).max(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).max(Sample.increment, session=session)
 
     assert n is None
 
@@ -76,9 +64,7 @@ async def test_min(preset_documents, session):
 
     assert n == 3
 
-    n = await Sample.find_many(Sample.integer == 1).min(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).min(Sample.increment, session=session)
 
     assert n == 3
 
@@ -88,8 +74,6 @@ async def test_min_without_docs(session):
 
     assert n is None
 
-    n = await Sample.find_many(Sample.integer == 1).min(
-        Sample.increment, session=session
-    )
+    n = await Sample.find_many(Sample.integer == 1).min(Sample.increment, session=session)
 
     assert n is None

--- a/tests/odm/query/test_delete.py
+++ b/tests/odm/query/test_delete.py
@@ -7,15 +7,13 @@ from tests.odm.models import Sample
 async def test_delete_many(preset_documents):
     count_before = await Sample.count()
     count_find = (
-        await Sample.find_many(Sample.integer > 1)
-        .find_many(Sample.nested.optional == None)
-        .count()
-    )  # noqa
+        await Sample.find_many(Sample.integer > 1).find_many(Sample.nested.optional == None).count()
+    )
     delete_result = (
         await Sample.find_many(Sample.integer > 1)
         .find_many(Sample.nested.optional == None)
         .delete()
-    )  # noqa
+    )
     count_deleted = delete_result.deleted_count
     count_after = await Sample.count()
     assert count_before - count_find == count_after
@@ -25,7 +23,7 @@ async def test_delete_many(preset_documents):
         .find_many(Sample.nested.optional == None)
         .delete_many(),
         DeleteMany,
-    )  # noqa
+    )
 
 
 async def test_delete_all(preset_documents):
@@ -43,7 +41,7 @@ async def test_delete_self(preset_documents):
         await Sample.find_many(Sample.integer > 1)
         .find_many(Sample.nested.optional == None)
         .to_list()
-    )  # noqa
+    )
     a = result[0]
     delete_result = await a.delete()
     count_deleted = delete_result.deleted_count
@@ -55,10 +53,8 @@ async def test_delete_self(preset_documents):
 async def test_delete_one(preset_documents):
     count_before = await Sample.count()
     delete_result = (
-        await Sample.find_one(Sample.integer > 1)
-        .find_one(Sample.nested.optional == None)
-        .delete()
-    )  # noqa
+        await Sample.find_one(Sample.integer > 1).find_one(Sample.nested.optional == None).delete()
+    )
     count_after = await Sample.count()
     count_deleted = delete_result.deleted_count
     assert count_before == count_after + 1
@@ -69,7 +65,7 @@ async def test_delete_one(preset_documents):
         await Sample.find_one(Sample.integer > 1)
         .find_one(Sample.nested.optional == None)
         .delete_one()
-    )  # noqa
+    )
     count_deleted = delete_result.deleted_count
     count_after = await Sample.count()
     assert count_before == count_after + 1
@@ -79,15 +75,13 @@ async def test_delete_one(preset_documents):
 async def test_delete_many_with_session(preset_documents, session):
     count_before = await Sample.count()
     count_find = (
-        await Sample.find_many(Sample.integer > 1)
-        .find_many(Sample.nested.optional == None)
-        .count()
-    )  # noqa
+        await Sample.find_many(Sample.integer > 1).find_many(Sample.nested.optional == None).count()
+    )
     q = (
         Sample.find_many(Sample.integer > 1)
         .find_many(Sample.nested.optional == None)
         .delete(session=session)
-    )  # noqa
+    )
     assert q.session == session
 
     q = (
@@ -95,7 +89,7 @@ async def test_delete_many_with_session(preset_documents, session):
         .find_many(Sample.nested.optional == None)
         .delete()
         .set_session(session=session)
-    )  # noqa
+    )
 
     assert q.session == session
 
@@ -110,12 +104,8 @@ async def test_delete_pymongo_kwargs(preset_documents):
     with pytest.raises(TypeError):
         await Sample.find_many(Sample.increment > 4).delete(wrong="integer_1")
 
-    delete_result = await Sample.find_many(Sample.increment > 4).delete(
-        hint="integer_1"
-    )
+    delete_result = await Sample.find_many(Sample.increment > 4).delete(hint="integer_1")
     assert delete_result is not None
 
-    delete_result = await Sample.find_one(Sample.increment > 4).delete(
-        hint="integer_1"
-    )
+    delete_result = await Sample.find_one(Sample.increment > 4).delete(hint="integer_1")
     assert delete_result is not None

--- a/tests/odm/query/test_find.py
+++ b/tests/odm/query/test_find.py
@@ -13,13 +13,11 @@ from tests.odm.models import (
 )
 
 
-async def test_find_query():
+def test_find_query():
     q = Sample.find_many(Sample.integer == 1).get_filter_query()
     assert q == {"integer": 1}
 
-    q = Sample.find_many(
-        Sample.integer == 1, Sample.nested.integer >= 2
-    ).get_filter_query()
+    q = Sample.find_many(Sample.integer == 1, Sample.nested.integer >= 2).get_filter_query()
     assert q == {"$and": [{"integer": 1}, {"nested.integer": {"$gte": 2}}]}
 
     q = (
@@ -38,16 +36,14 @@ async def test_find_many(preset_documents):
         await Sample.find_many(Sample.integer > 1)
         .find_many(Sample.nested.optional == None)
         .to_list()
-    )  # noqa
+    )
     assert len(result) == 2
     for a in result:
         assert a.integer > 1
         assert a.nested.optional is None
 
     len_result = 0
-    async for a in Sample.find_many(Sample.integer > 1).find_many(
-        Sample.nested.optional == None
-    ):  # noqa
+    async for a in Sample.find_many(Sample.integer > 1).find_many(Sample.nested.optional == None):
         assert a in result
         len_result += 1
 
@@ -74,10 +70,8 @@ async def test_find_many_skip(preset_documents):
 
     len_result = 0
     async for sample in (
-        Sample.find_many(Sample.increment > 2)
-        .find_many(Sample.nested.optional == None)
-        .skip(1)
-    ):  # noqa
+        Sample.find_many(Sample.increment > 2).find_many(Sample.nested.optional == None).skip(1)
+    ):
         assert sample in result
         len_result += 1
 
@@ -97,7 +91,7 @@ async def test_find_many_limit(preset_documents):
         .sort(Sample.increment)
         .limit(2)
         .to_list()
-    )  # noqa
+    )
     assert len(result) == 2
     for a in result:
         assert a.increment > 2
@@ -109,7 +103,7 @@ async def test_find_many_limit(preset_documents):
         .find(Sample.nested.optional == None)
         .sort(Sample.increment)
         .limit(2)
-    ):  # noqa
+    ):
         assert a in result
         len_result += 1
 
@@ -129,22 +123,16 @@ async def test_find_all(preset_documents):
 
 
 async def test_find_one(preset_documents):
-    a = await Sample.find_one(Sample.integer > 1).find_one(
-        Sample.nested.optional == None
-    )  # noqa
+    a = await Sample.find_one(Sample.integer > 1).find_one(Sample.nested.optional == None)
     assert a.integer > 1
     assert a.nested.optional is None
 
-    a = await Sample.find_one(Sample.integer > 100).find_one(
-        Sample.nested.optional == None
-    )  # noqa
+    a = await Sample.find_one(Sample.integer > 100).find_one(Sample.nested.optional == None)
     assert a is None
 
 
 async def test_get(preset_documents):
-    a = await Sample.find_one(Sample.integer > 1).find_one(
-        Sample.nested.optional == None
-    )  # noqa
+    a = await Sample.find_one(Sample.integer > 1).find_one(Sample.nested.optional == None)
     assert a.integer > 1
     assert a.nested.optional is None
 
@@ -166,16 +154,10 @@ async def test_sort(preset_documents):
     q = Sample.find_many(Sample.integer > 1).sort("-integer")
     assert q.sort_expressions == [("integer", SortDirection.DESCENDING)]
 
-    q = (
-        Sample.find_many(Sample.integer > 1)
-        .find_many(Sample.integer < 100)
-        .sort("-integer")
-    )
+    q = Sample.find_many(Sample.integer > 1).find_many(Sample.integer < 100).sort("-integer")
     assert q.sort_expressions == [("integer", SortDirection.DESCENDING)]
 
-    result = await Sample.find_many(
-        Sample.integer > 1, sort="-integer"
-    ).to_list()
+    result = await Sample.find_many(Sample.integer > 1, sort="-integer").to_list()
     i_buf = None
     for a in result:
         if i_buf is None:
@@ -183,9 +165,7 @@ async def test_sort(preset_documents):
         assert i_buf >= a.integer
         i_buf = a.integer
 
-    result = await Sample.find_many(
-        Sample.integer > 1, sort="+integer"
-    ).to_list()
+    result = await Sample.find_many(Sample.integer > 1, sort="+integer").to_list()
     i_buf = None
     for a in result:
         if i_buf is None:
@@ -193,9 +173,7 @@ async def test_sort(preset_documents):
         assert i_buf <= a.integer
         i_buf = a.integer
 
-    result = await Sample.find_many(
-        Sample.integer > 1, sort="integer"
-    ).to_list()
+    result = await Sample.find_many(Sample.integer > 1, sort="integer").to_list()
     i_buf = None
     for a in result:
         if i_buf is None:
@@ -203,9 +181,7 @@ async def test_sort(preset_documents):
         assert i_buf <= a.integer
         i_buf = a.integer
 
-    result = await Sample.find_many(
-        Sample.integer > 1, sort=-Sample.integer
-    ).to_list()
+    result = await Sample.find_many(Sample.integer > 1, sort=-Sample.integer).to_list()
     i_buf = None
     for a in result:
         if i_buf is None:
@@ -214,9 +190,7 @@ async def test_sort(preset_documents):
         i_buf = a.integer
 
     result = (
-        await Sample.find_many(Sample.integer > 1)
-        .sort([Sample.const, -Sample.integer])
-        .to_list()
+        await Sample.find_many(Sample.integer > 1).sort([Sample.const, -Sample.integer]).to_list()
     )
     i_buf = None
     for a in result:
@@ -247,9 +221,7 @@ async def test_find_many_with_projection(preset_documents):
 
     result = (
         await Sample.find_many(Sample.integer > 1)
-        .find_many(
-            Sample.nested.optional == None, projection_model=SampleProjection
-        )
+        .find_many(Sample.nested.optional == None, projection_model=SampleProjection)
         .to_list()
     )
     assert result == [
@@ -300,9 +272,7 @@ async def test_find_many_with_session(preset_documents, session):
         assert a.nested.optional is None
 
     len_result = 0
-    async for a in Sample.find_many(Sample.integer > 1).find_many(
-        Sample.nested.optional == None
-    ):  # noqa
+    async for a in Sample.find_many(Sample.integer > 1).find_many(Sample.nested.optional == None):
         assert a in result
         len_result += 1
 
@@ -322,12 +292,8 @@ async def test_bson_encoders_filed_types():
 
 
 async def test_find_by_datetime(preset_documents):
-    datetime_1 = datetime.datetime.now(
-        tz=datetime.timezone.utc
-    ) - datetime.timedelta(days=7)
-    datetime_2 = datetime.datetime.now(
-        tz=datetime.timezone.utc
-    ) - datetime.timedelta(days=2)
+    datetime_1 = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=7)
+    datetime_2 = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(days=2)
     docs = await Sample.find(
         Sample.timestamp >= datetime_1,
         Sample.timestamp <= datetime_2,
@@ -344,11 +310,7 @@ async def test_find_first_or_none(preset_documents):
     docs = await q.to_list()
     assert len(docs) == 8
 
-    doc = (
-        await Sample.find(Sample.increment > 9)
-        .sort(-Sample.increment)
-        .first_or_none()
-    )
+    doc = await Sample.find(Sample.increment > 9).sort(-Sample.increment).first_or_none()
     assert doc is None
 
 
@@ -356,25 +318,15 @@ async def test_find_pymongo_kwargs(preset_documents):
     with pytest.raises(TypeError):
         await Sample.find_many(Sample.increment > 1, wrong=100).to_list()
 
-    await Sample.find_many(
-        Sample.increment > 1, Sample.integer > 1, allow_disk_use=True
-    ).to_list()
+    await Sample.find_many(Sample.increment > 1, Sample.integer > 1, allow_disk_use=True).to_list()
 
-    await Sample.find_many(
-        Sample.increment > 1, Sample.integer > 1, hint="integer_1"
-    ).to_list()
+    await Sample.find_many(Sample.increment > 1, Sample.integer > 1, hint="integer_1").to_list()
 
-    await House.find_many(
-        House.height > 1, fetch_links=True, hint="height_1"
-    ).to_list()
+    await House.find_many(House.height > 1, fetch_links=True, hint="height_1").to_list()
 
-    await House.find_many(
-        House.height > 1, fetch_links=True, allowDiskUse=True
-    ).to_list()
+    await House.find_many(House.height > 1, fetch_links=True, allowDiskUse=True).to_list()
 
-    await Sample.find_one(
-        Sample.increment > 1, Sample.integer > 1, hint="integer_1"
-    )
+    await Sample.find_one(Sample.increment > 1, Sample.integer > 1, hint="integer_1")
 
     await House.find_one(House.height > 1, fetch_links=True, hint="height_1")
 
@@ -390,9 +342,7 @@ def test_find_clone():
     new_q = q.clone()
     new_q.find(Sample.nested.integer >= 100).sort(Sample.string).limit(10)
 
-    assert q.get_filter_query() == {
-        "$and": [{"integer": 1}, {"nested.integer": {"$gte": 2}}]
-    }
+    assert q.get_filter_query() == {"$and": [{"integer": 1}, {"nested.integer": {"$gte": 2}}]}
     assert q.sort_expressions == [("integer", SortDirection.ASCENDING)]
     assert q.limit_number == 100
     assert new_q.get_filter_query() == {

--- a/tests/odm/query/test_update.py
+++ b/tests/odm/query/test_update.py
@@ -7,12 +7,8 @@ from beanie.odm.queries.update import UpdateResponse
 from tests.odm.models import Sample
 
 
-async def test_update_query():
-    q = (
-        Sample.find_many(Sample.integer == 1)
-        .update(Set({Sample.integer: 10}))
-        .update_query
-    )
+def test_update_query():
+    q = Sample.find_many(Sample.integer == 1).update(Set({Sample.integer: 10})).update_query
     assert q == {"$set": {"integer": 10}}
 
     q = (
@@ -54,7 +50,7 @@ async def test_update_many(preset_documents):
         Sample.find_many(Sample.increment > 4)
         .find_many(Sample.nested.optional == None)
         .update(Set({Sample.increment: 100}))
-    )  # noqa
+    )
     result = await Sample.find_many(Sample.increment == 100).to_list()
     assert len(result) == 3
     for sample in result:
@@ -66,7 +62,7 @@ async def test_update_many_linked_method(preset_documents):
         Sample.find_many(Sample.increment > 4)
         .find_many(Sample.nested.optional == None)
         .update_many(Set({Sample.increment: 100}))
-    )  # noqa
+    )
     result = await Sample.find_many(Sample.increment == 100).to_list()
     assert len(result) == 3
     for sample in result:
@@ -86,16 +82,12 @@ async def test_update_all(preset_documents):
 
 
 async def test_update_one(preset_documents):
-    await Sample.find_one(Sample.integer == 1).update(
-        Set({Sample.integer: 100})
-    )
+    await Sample.find_one(Sample.integer == 1).update(Set({Sample.integer: 100}))
     result = await Sample.find_many(Sample.integer == 100).to_list()
     assert len(result) == 1
     assert result[0].integer == 100
 
-    await Sample.find_one(Sample.integer == 1).update_one(
-        Set({Sample.integer: 101})
-    )
+    await Sample.find_one(Sample.integer == 1).update_one(Set({Sample.integer: 101}))
     result = await Sample.find_many(Sample.integer == 101).to_list()
     assert len(result) == 1
     assert result[0].integer == 101
@@ -134,70 +126,52 @@ async def test_update_many_with_session(preset_documents, session):
     )
     assert q.session == session
 
-    await q  # noqa
+    await q
     result = await Sample.find_many(Sample.increment == 100).to_list()
     assert len(result) == 3
     for sample in result:
         assert sample.increment == 100
 
 
-async def test_update_many_upsert_with_insert(
-    preset_documents, sample_doc_not_saved
-):
+async def test_update_many_upsert_with_insert(preset_documents, sample_doc_not_saved):
     await Sample.find_many(Sample.integer > 100000).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
     await asyncio.sleep(2)
-    new_docs = await Sample.find_many(
-        Sample.string == sample_doc_not_saved.string
-    ).to_list()
+    new_docs = await Sample.find_many(Sample.string == sample_doc_not_saved.string).to_list()
     assert len(new_docs) == 1
     doc = new_docs[0]
     assert doc.integer == sample_doc_not_saved.integer
 
 
-async def test_update_many_upsert_without_insert(
-    preset_documents, sample_doc_not_saved
-):
+async def test_update_many_upsert_without_insert(preset_documents, sample_doc_not_saved):
     await Sample.find_many(Sample.integer > 1).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
     await asyncio.sleep(2)
-    new_docs = await Sample.find_many(
-        Sample.string == sample_doc_not_saved.string
-    ).to_list()
+    new_docs = await Sample.find_many(Sample.string == sample_doc_not_saved.string).to_list()
     assert len(new_docs) == 0
 
 
-async def test_update_one_upsert_with_insert(
-    preset_documents, sample_doc_not_saved
-):
+async def test_update_one_upsert_with_insert(preset_documents, sample_doc_not_saved):
     await Sample.find_one(Sample.integer > 100000).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
-    new_docs = await Sample.find_many(
-        Sample.string == sample_doc_not_saved.string
-    ).to_list()
+    new_docs = await Sample.find_many(Sample.string == sample_doc_not_saved.string).to_list()
     assert len(new_docs) == 1
     doc = new_docs[0]
     assert doc.integer == sample_doc_not_saved.integer
 
 
-async def test_update_one_upsert_without_insert(
-    preset_documents, sample_doc_not_saved
-):
+async def test_update_one_upsert_without_insert(preset_documents, sample_doc_not_saved):
     await Sample.find_one(Sample.integer > 1).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
-    new_docs = await Sample.find_many(
-        Sample.string == sample_doc_not_saved.string
-    ).to_list()
+    new_docs = await Sample.find_many(Sample.string == sample_doc_not_saved.string).to_list()
     assert len(new_docs) == 0
 
 
-async def test_update_one_upsert_without_insert_return_doc(
-    preset_documents, sample_doc_not_saved
-):
+async def test_update_one_upsert_without_insert_return_doc(preset_documents, sample_doc_not_saved):
     result = await Sample.find_one(Sample.integer > 1).upsert(
         Set({Sample.integer: 100}),
         on_insert=sample_doc_not_saved,
@@ -205,9 +179,7 @@ async def test_update_one_upsert_without_insert_return_doc(
     )
     assert isinstance(result, Sample)
 
-    new_docs = await Sample.find_many(
-        Sample.string == sample_doc_not_saved.string
-    ).to_list()
+    new_docs = await Sample.find_many(Sample.string == sample_doc_not_saved.string).to_list()
     assert len(new_docs) == 0
 
 

--- a/tests/odm/query/test_update_methods.py
+++ b/tests/odm/query/test_update_methods.py
@@ -3,10 +3,8 @@ from beanie.odm.queries.update import UpdateMany, UpdateQuery
 from tests.odm.models import Sample
 
 
-async def test_set(session):
-    q = Sample.find_many(Sample.integer == 1).set(
-        {Sample.integer: 100}, session=session
-    )
+def test_set(session):
+    q = Sample.find_many(Sample.integer == 1).set({Sample.integer: 100}, session=session)
 
     assert isinstance(q, UpdateQuery)
     assert isinstance(q, UpdateMany)
@@ -29,7 +27,7 @@ async def test_set(session):
     }
 
 
-async def test_current_date(session):
+def test_current_date(session):
     q = Sample.find_many(Sample.integer == 1).current_date(
         {Sample.timestamp: "timestamp"}, session=session
     )
@@ -55,10 +53,8 @@ async def test_current_date(session):
     }
 
 
-async def test_inc(session):
-    q = Sample.find_many(Sample.integer == 1).inc(
-        {Sample.integer: 100}, session=session
-    )
+def test_inc(session):
+    q = Sample.find_many(Sample.integer == 1).inc({Sample.integer: 100}, session=session)
 
     assert isinstance(q, UpdateQuery)
     assert isinstance(q, UpdateMany)

--- a/tests/odm/test_cache.py
+++ b/tests/odm/test_cache.py
@@ -12,9 +12,7 @@ async def test_find_one(documents):
     new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
     assert doc == new_doc
 
-    new_doc = await DocumentTestModel.find_one(
-        DocumentTestModel.test_int == 1, ignore_cache=True
-    )
+    new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1, ignore_cache=True)
     assert doc != new_doc
 
     await asyncio.sleep(10)
@@ -25,17 +23,13 @@ async def test_find_one(documents):
 
 async def test_find_many(documents):
     await documents(5)
-    docs = await DocumentTestModel.find(
-        DocumentTestModel.test_int > 1
-    ).to_list()
+    docs = await DocumentTestModel.find(DocumentTestModel.test_int > 1).to_list()
 
     await DocumentTestModel.find(DocumentTestModel.test_int > 1).set(
         {DocumentTestModel.test_str: "NEW_VALUE"}
     )
 
-    new_docs = await DocumentTestModel.find(
-        DocumentTestModel.test_int > 1
-    ).to_list()
+    new_docs = await DocumentTestModel.find(DocumentTestModel.test_int > 1).to_list()
     assert docs == new_docs
 
     new_docs = await DocumentTestModel.find(
@@ -45,9 +39,7 @@ async def test_find_many(documents):
 
     await asyncio.sleep(10)
 
-    new_docs = await DocumentTestModel.find(
-        DocumentTestModel.test_int > 1
-    ).to_list()
+    new_docs = await DocumentTestModel.find(DocumentTestModel.test_int > 1).to_list()
     assert docs != new_docs
 
 
@@ -84,9 +76,7 @@ async def test_capacity(documents):
     await documents(10)
     docs = []
     for i in range(10):
-        docs.append(
-            await DocumentTestModel.find_one(DocumentTestModel.test_int == i)
-        )
+        docs.append(await DocumentTestModel.find_one(DocumentTestModel.test_int == i))
 
     await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).set(
         {DocumentTestModel.test_str: "NEW_VALUE"}

--- a/tests/odm/test_concurrency.py
+++ b/tests/odm/test_concurrency.py
@@ -24,9 +24,7 @@ class TestConcurrency:
             client.get_io_loop = asyncio.get_running_loop
             clients.append(client)
             db = client[settings.mongodb_db_name]
-            await init_beanie(
-                db, document_models=[SampleModel3, SampleModel, SampleModel2]
-            )
+            await init_beanie(db, document_models=[SampleModel3, SampleModel, SampleModel2])
 
             async def insert_find():
                 await SampleModel2().insert()

--- a/tests/odm/test_encoder.py
+++ b/tests/odm/test_encoder.py
@@ -76,9 +76,7 @@ async def test_encode_regex():
 
 
 def test_encode_with_custom_encoder():
-    assert isinstance(
-        Encoder(custom_encoders={datetime: str}).encode(datetime.now()), str
-    )
+    assert isinstance(Encoder(custom_encoders={datetime: str}).encode(datetime.now()), str)
 
 
 async def test_bytes():
@@ -92,7 +90,7 @@ async def test_bytes():
     assert isinstance(new_doc.bytes_field, bytes)
 
 
-async def test_bytes_already_binary():
+def test_bytes_already_binary():
     b = Binary(b"123", 3)
     encoded_b = Encoder().encode(b)
     assert isinstance(encoded_b, Binary)
@@ -153,9 +151,7 @@ async def test_should_be_able_to_save_retrieve_doc_with_url():
     assert isinstance(doc.url_field, AnyUrl)
     await doc.save()
 
-    new_doc = await DocumentWithHttpUrlField.find_one(
-        DocumentWithHttpUrlField.id == doc.id
-    )
+    new_doc = await DocumentWithHttpUrlField.find_one(DocumentWithHttpUrlField.id == doc.id)
 
     assert isinstance(new_doc.url_field, AnyUrl)
     assert new_doc.url_field == doc.url_field

--- a/tests/odm/test_expression_fields.py
+++ b/tests/odm/test_expression_fields.py
@@ -18,16 +18,12 @@ def test_nesting():
     assert q.get_filter_query() == {"union.s": "test"}
     assert Sample.union.s == "union.s"
 
-    q = Sample.find_many(Sample.nested.optional == None)  # noqa
+    q = Sample.find_many(Sample.nested.optional == None)
     assert q.get_filter_query() == {"nested.optional": None}
     assert Sample.nested.optional == "nested.optional"
 
-    q = Sample.find_many(Sample.nested.integer == 1).find_many(
-        Sample.nested.union.s == "test"
-    )
-    assert q.get_filter_query() == {
-        "$and": [{"nested.integer": 1}, {"nested.union.s": "test"}]
-    }
+    q = Sample.find_many(Sample.nested.integer == 1).find_many(Sample.nested.union.s == "test")
+    assert q.get_filter_query() == {"$and": [{"nested.integer": 1}, {"nested.union.s": "test"}]}
 
 
 def test_eq():

--- a/tests/odm/test_fields.py
+++ b/tests/odm/test_fields.py
@@ -1,7 +1,7 @@
 import datetime
+from collections.abc import Mapping
 from decimal import Decimal
 from pathlib import Path
-from typing import AbstractSet, Mapping
 from uuid import uuid4
 
 import pytest
@@ -102,12 +102,8 @@ async def test_custom_filed_types():
     c2_fromdb_encoded = Encoder().encode(c2_fromdb)
     assert c1_fromdb_encoded == c1_encoded
     assert c2_fromdb_encoded == c2_encoded
-    assert Decimal(str(custom1.decimal)) == Decimal(
-        str(c1_encoded.get("decimal"))
-    )
-    assert Decimal(str(custom2.decimal)) == Decimal(
-        str(c2_encoded.get("decimal"))
-    )
+    assert Decimal(str(custom1.decimal)) == Decimal(str(c1_encoded.get("decimal")))
+    assert Decimal(str(custom2.decimal)) == Decimal(str(c2_encoded.get("decimal")))
 
 
 async def test_excluded(document):
@@ -155,14 +151,14 @@ async def test_param_exclude(document, exclude):
         doc_dict = document.model_dump(exclude=exclude)
     else:
         doc_dict = document.dict(exclude=exclude)
-    if isinstance(exclude, AbstractSet):
+    if isinstance(exclude, set):
         for k in exclude:
             assert k not in doc_dict
     elif isinstance(exclude, Mapping):
         for k, v in exclude.items():
             if isinstance(v, bool) and v:
                 assert k not in doc_dict
-            elif isinstance(v, AbstractSet):
+            elif isinstance(v, set):
                 for another_k in v:
                     assert another_k not in doc_dict[k]
 

--- a/tests/odm/test_id.py
+++ b/tests/odm/test_id.py
@@ -30,7 +30,7 @@ async def test_integer_id():
     not IS_PYDANTIC_V2,
     reason="supports only pydantic v2",
 )
-async def test_pydantic_object_id_validation_json():
+def test_pydantic_object_id_validation_json():
     deserialized = A.model_validate_json('{"id": "5eb7cf5a86d9755df3a6c593"}')
     assert isinstance(deserialized.id, PydanticObjectId)
     assert str(deserialized.id) == "5eb7cf5a86d9755df3a6c593"
@@ -48,7 +48,7 @@ async def test_pydantic_object_id_validation_json():
         PydanticObjectId("5eb7cf5a86d9755df3a6c593"),
     ],
 )
-async def test_pydantic_object_id_serialization(data):
+def test_pydantic_object_id_serialization(data):
     deserialized = A(**{"id": data})
     assert isinstance(deserialized.id, PydanticObjectId)
     assert str(deserialized.id) == "5eb7cf5a86d9755df3a6c593"

--- a/tests/odm/test_json_schema_generation.py
+++ b/tests/odm/test_json_schema_generation.py
@@ -21,14 +21,8 @@ def test_schema_export_of_model_with_decimal_field():
 
         assert json_schema["properties"]["amt"]["anyOf"][0]["type"] == "number"
         assert json_schema["properties"]["amt"]["anyOf"][1]["type"] == "string"
-        assert (
-            json_schema["properties"]["other_amt"]["anyOf"][0]["type"]
-            == "number"
-        )
-        assert (
-            json_schema["properties"]["other_amt"]["anyOf"][1]["type"]
-            == "string"
-        )
+        assert json_schema["properties"]["other_amt"]["anyOf"][0]["type"] == "number"
+        assert json_schema["properties"]["other_amt"]["anyOf"][1]["type"] == "string"
 
     else:
         json_schema = doc.schema()
@@ -44,14 +38,8 @@ def test_schema_export_of_model_with_pydanticobjectid():
     if IS_PYDANTIC_V2:
         json_schema = doc.model_json_schema()
 
-        assert (
-            json_schema["properties"]["_id"]["anyOf"][0]["$ref"]
-            == "#/$defs/PydanticObjectId"
-        )
-        assert (
-            json_schema["properties"]["pyid"]["$ref"]
-            == "#/$defs/PydanticObjectId"
-        )
+        assert json_schema["properties"]["_id"]["anyOf"][0]["$ref"] == "#/$defs/PydanticObjectId"
+        assert json_schema["properties"]["pyid"]["$ref"] == "#/$defs/PydanticObjectId"
     else:
         json_schema = doc.schema()
 
@@ -63,15 +51,13 @@ def test_schema_export_of_model_with_link():
     if IS_PYDANTIC_V2:
         json_schema = DocumentWithLink.model_json_schema()
 
-        link_alternate_representation = json_schema["properties"]["link"][
-            "anyOf"
-        ]
+        link_alternate_representation = json_schema["properties"]["link"]["anyOf"]
     else:
         json_schema = DocumentWithLink.schema()
 
-        link_alternate_representation = json_schema["definitions"][
-            "DocumentWithLink"
-        ]["properties"]["link"]["anyOf"]
+        link_alternate_representation = json_schema["definitions"]["DocumentWithLink"][
+            "properties"
+        ]["link"]["anyOf"]
 
     assert link_alternate_representation[0]["type"] == "object"
     assert link_alternate_representation[1]["type"] == "object"
@@ -97,19 +83,17 @@ def test_schema_export_of_model_with_list_link():
     if IS_PYDANTIC_V2:
         json_schema = DocumentWithListLink.model_json_schema()
 
-        link_alternate_representation = json_schema["properties"]["link"][
-            "items"
-        ]["anyOf"]
+        link_alternate_representation = json_schema["properties"]["link"]["items"]["anyOf"]
         link_definition = json_schema["properties"]["link"]["type"]
     else:
         json_schema = DocumentWithListLink.schema()
 
-        link_alternate_representation = json_schema["definitions"][
-            "DocumentWithListLink"
-        ]["properties"]["link"]["items"]["anyOf"]
-        link_definition = json_schema["definitions"]["DocumentWithListLink"][
+        link_alternate_representation = json_schema["definitions"]["DocumentWithListLink"][
             "properties"
-        ]["link"]["type"]
+        ]["link"]["items"]["anyOf"]
+        link_definition = json_schema["definitions"]["DocumentWithListLink"]["properties"]["link"][
+            "type"
+        ]
 
     assert link_definition == "array"
     assert link_alternate_representation[0]["type"] == "object"
@@ -124,9 +108,9 @@ def test_schema_export_of_model_with_backlink():
     else:
         json_schema = DocumentWithBackLink.schema()
 
-        back_link_definition = json_schema["definitions"][
-            "DocumentWithBackLink"
-        ]["properties"]["back_link"]["anyOf"][1]["type"]
+        back_link_definition = json_schema["definitions"]["DocumentWithBackLink"]["properties"][
+            "back_link"
+        ]["anyOf"][1]["type"]
 
     assert back_link_definition == "object"
 
@@ -136,22 +120,20 @@ def test_schema_export_of_model_with_list_backlink():
         json_schema = DocumentWithListBackLink.model_json_schema()
 
         assert json_schema["properties"]["back_link"]["type"] == "array"
-        assert (
-            json_schema["properties"]["back_link"]["items"]["type"] == "object"
-        )
+        assert json_schema["properties"]["back_link"]["items"]["type"] == "object"
     else:
         json_schema = DocumentWithListBackLink.schema()
 
         assert (
-            json_schema["definitions"]["DocumentWithListBackLink"][
-                "properties"
-            ]["back_link"]["type"]
+            json_schema["definitions"]["DocumentWithListBackLink"]["properties"]["back_link"][
+                "type"
+            ]
             == "array"
         )
         assert (
-            json_schema["definitions"]["DocumentWithListBackLink"][
-                "properties"
-            ]["back_link"]["items"]["anyOf"][1]["type"]
+            json_schema["definitions"]["DocumentWithListBackLink"]["properties"]["back_link"][
+                "items"
+            ]["anyOf"][1]["type"]
             == "object"
         )
 

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 from pydantic.fields import Field
 
@@ -84,9 +82,7 @@ def door_not_inserted(window_not_inserted, locks_not_inserted):
 
 @pytest.fixture
 def house_not_inserted(windows_not_inserted, door_not_inserted):
-    return House(
-        windows=windows_not_inserted, door=door_not_inserted, name="test"
-    )
+    return House(windows=windows_not_inserted, door=door_not_inserted, name="test")
 
 
 @pytest.fixture
@@ -105,9 +101,7 @@ async def houses():
         house = await House(
             door=Door(
                 t=i,
-                window=Window(x=20, y=21 + i, lock=Lock(k=20 + i))
-                if i % 2 == 0
-                else None,
+                window=Window(x=20, y=21 + i, lock=Lock(k=20 + i)) if i % 2 == 0 else None,
                 locks=[Lock(k=20 + i)],
             ),
             windows=[
@@ -214,11 +208,7 @@ class TestFind:
         assert items[0].roof is None
         assert isinstance(items[1].roof, Link)
 
-        items = (
-            await House.find(House.height > 2, fetch_links=True)
-            .sort(House.height)
-            .to_list()
-        )
+        items = await House.find(House.height > 2, fetch_links=True).sort(House.height).to_list()
         assert len(items) == 7
         for window in items[0].windows:
             assert isinstance(window, Window)
@@ -235,9 +225,7 @@ class TestFind:
         assert items[0].roof is None
         assert isinstance(items[1].roof, Roof)
 
-        houses = await House.find_many(
-            House.height == 9, fetch_links=True
-        ).to_list()
+        houses = await House.find_many(House.height == 9, fetch_links=True).to_list()
         assert len(houses[0].windows) == 1
         assert isinstance(houses[0].windows[0].lock, Link)
         assert isinstance(houses[0].door, Link)
@@ -245,21 +233,15 @@ class TestFind:
         await houses[0].fetch_link(House.door)
         assert isinstance(houses[0].door, Link)
 
-        houses = await House.find_many(
-            House.door.t > 5, fetch_links=True
-        ).to_list()
+        houses = await House.find_many(House.door.t > 5, fetch_links=True).to_list()
 
         assert len(houses) == 3
 
-        houses = await House.find_many(
-            House.windows.y == 15, fetch_links=True
-        ).to_list()
+        houses = await House.find_many(House.windows.y == 15, fetch_links=True).to_list()
 
         assert len(houses) == 2
 
-        houses = await House.find_many(
-            House.height > 5, limit=3, fetch_links=True
-        ).to_list()
+        houses = await House.find_many(House.height > 5, limit=3, fetch_links=True).to_list()
 
         assert len(houses) == 3
 
@@ -317,28 +299,18 @@ class TestFind:
             assert isinstance(window.lock, Lock)
 
     async def test_find_by_id_of_the_linked_docs(self, house):
-        house_lst_1 = await House.find(
-            House.door.id == house.door.id
-        ).to_list()
-        house_lst_2 = await House.find(
-            House.door.id == house.door.id, fetch_links=True
-        ).to_list()
+        house_lst_1 = await House.find(House.door.id == house.door.id).to_list()
+        house_lst_2 = await House.find(House.door.id == house.door.id, fetch_links=True).to_list()
         assert len(house_lst_1) == 1
         assert len(house_lst_2) == 1
 
         house_1 = await House.find_one(House.door.id == house.door.id)
-        house_2 = await House.find_one(
-            House.door.id == house.door.id, fetch_links=True
-        )
+        house_2 = await House.find_one(House.door.id == house.door.id, fetch_links=True)
         assert house_1 is not None
         assert house_2 is not None
 
     async def test_find_by_id_list_of_the_linked_docs(self, houses):
-        items = (
-            await House.find(House.height < 3, fetch_links=True)
-            .sort(House.height)
-            .to_list()
-        )
+        items = await House.find(House.height < 3, fetch_links=True).sort(House.height).to_list()
         assert len(items) == 3
 
         house_lst_1 = await House.find(
@@ -360,7 +332,7 @@ class TestFind:
 
     async def test_fetch_list_with_some_prefetched(self):
         docs = []
-        for i in range(10):
+        for _ in range(10):
             doc = DocumentToBeLinked()
             await doc.save()
             docs.append(doc)
@@ -368,9 +340,7 @@ class TestFind:
         doc_with_links = DocumentWithListOfLinks(links=docs)
         await doc_with_links.save()
 
-        doc_with_links = await DocumentWithListOfLinks.get(
-            doc_with_links.id, fetch_links=False
-        )
+        doc_with_links = await DocumentWithListOfLinks.get(doc_with_links.id, fetch_links=False)
         doc_with_links.links[-1] = await doc_with_links.links[-1].fetch()
 
         await doc_with_links.fetch_all_links()
@@ -385,14 +355,10 @@ class TestFind:
             assert doc_with_links.links[i].id == docs[i].id
 
     async def test_text_search(self):
-        doc = DocumentWithTextIndexAndLink(
-            s="hello world", link=LinkDocumentForTextSeacrh(i=1)
-        )
+        doc = DocumentWithTextIndexAndLink(s="hello world", link=LinkDocumentForTextSeacrh(i=1))
         await doc.insert(link_rule=WriteRules.WRITE)
 
-        doc2 = DocumentWithTextIndexAndLink(
-            s="hi world", link=LinkDocumentForTextSeacrh(i=2)
-        )
+        doc2 = DocumentWithTextIndexAndLink(s="hi world", link=LinkDocumentForTextSeacrh(i=2))
         await doc2.insert(link_rule=WriteRules.WRITE)
 
         docs = await DocumentWithTextIndexAndLink.find(
@@ -406,15 +372,11 @@ class TestFind:
         self_linked_doc.link = self_linked_doc
         await self_linked_doc.save()
 
-        self_linked_doc = await LongSelfLink.find_one(
-            nesting_depth=4, fetch_links=True
-        )
+        self_linked_doc = await LongSelfLink.find_one(nesting_depth=4, fetch_links=True)
         assert self_linked_doc.link.link.link.link.id == self_linked_doc.id
         assert isinstance(self_linked_doc.link.link.link.link.link, Link)
 
-        self_linked_doc = await LongSelfLink.find_one(
-            nesting_depth=0, fetch_links=True
-        )
+        self_linked_doc = await LongSelfLink.find_one(nesting_depth=0, fetch_links=True)
         assert isinstance(self_linked_doc.link, Link)
 
     async def test_nesting_find_parameters(self):
@@ -525,20 +487,14 @@ class TestOther:
         assert set(BDocument._link_fields.keys()) == {"link_root", "link_b"}
 
     async def test_with_projection(self):
-        await UsersAddresses(region_id=Region()).insert(
-            link_rule=WriteRules.WRITE
-        )
-        res = await UsersAddresses.find_one(fetch_links=True).project(
-            AddressView
-        )
+        await UsersAddresses(region_id=Region()).insert(link_rule=WriteRules.WRITE)
+        res = await UsersAddresses.find_one(fetch_links=True).project(AddressView)
         assert res.id is not None
         assert res.state == "TEST"
         assert res.city == "TEST"
 
     async def test_self_linked(self):
-        await SelfLinked(item=SelfLinked(s="2"), s="1").insert(
-            link_rule=WriteRules.WRITE
-        )
+        await SelfLinked(item=SelfLinked(s="2"), s="1").insert(link_rule=WriteRules.WRITE)
 
         res = await SelfLinked.find_one(fetch_links=True)
         assert isinstance(res, SelfLinked)
@@ -547,9 +503,7 @@ class TestOther:
         await SelfLinked.delete_all()
 
         await SelfLinked(
-            item=SelfLinked(
-                item=SelfLinked(item=SelfLinked(s="4"), s="3"), s="2"
-            ),
+            item=SelfLinked(item=SelfLinked(item=SelfLinked(s="4"), s="3"), s="2"),
             s="1",
         ).insert(link_rule=WriteRules.WRITE)
 
@@ -572,9 +526,7 @@ class TestOther:
             ),
             s="1",
         ).insert(link_rule=WriteRules.WRITE)
-        res = await LoopedLinksA.find_one(
-            LoopedLinksA.s == "1", fetch_links=True
-        )
+        res = await LoopedLinksA.find_one(LoopedLinksA.s == "1", fetch_links=True)
         assert isinstance(res, LoopedLinksA)
         assert isinstance(res.b, LoopedLinksB)
         assert isinstance(res.b.a, LoopedLinksA)
@@ -584,9 +536,7 @@ class TestOther:
             b=LoopedLinksB(s="a2"),
             s="a1",
         ).insert(link_rule=WriteRules.WRITE)
-        res = await LoopedLinksA.find_one(
-            LoopedLinksA.s == "a1", fetch_links=True
-        )
+        res = await LoopedLinksA.find_one(LoopedLinksA.s == "a1", fetch_links=True)
         assert isinstance(res, LoopedLinksA)
         assert isinstance(res.b, LoopedLinksB)
         assert res.b.a is None
@@ -595,19 +545,17 @@ class TestOther:
         region = Region()
         await region.insert()
 
-        for i in range(10):
+        for _ in range(10):
             await UsersAddresses(region_id=region).insert()
 
         region_2 = Region()
         await region_2.insert()
 
-        for i in range(10):
+        for _ in range(10):
             await UsersAddresses(region_id=region_2).insert()
 
         addresses_count = (
-            await UsersAddresses.find(
-                UsersAddresses.region_id.id == region.id, fetch_links=True
-            )
+            await UsersAddresses.find(UsersAddresses.region_id.id == region.id, fetch_links=True)
             .aggregate([{"$count": "count"}])
             .to_list()
         )
@@ -644,9 +592,7 @@ class TestOther:
         )
 
         # Test both aggregation and count methods
-        document_count_aggregation = await query.aggregate(
-            [{"$count": "count"}]
-        ).to_list()
+        document_count_aggregation = await query.aggregate([{"$count": "count"}]).to_list()
         document_count = await query.count()
 
         # ASSERT
@@ -700,17 +646,13 @@ async def list_link_and_list_backlink_doc_pair():
 class TestFindBackLinks:
     async def test_prefetch_direct(self, link_and_backlink_doc_pair):
         link_doc, back_link_doc = link_and_backlink_doc_pair
-        back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         assert back_link_doc.back_link.id == link_doc.id
         assert back_link_doc.back_link.link.id == back_link_doc.id
 
     async def test_prefetch_list(self, list_link_and_list_backlink_doc_pair):
         link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
-        back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         assert back_link_doc.back_link[0].id == link_doc.id
         assert back_link_doc.back_link[0].link[0].id == back_link_doc.id
 
@@ -720,125 +662,86 @@ class TestFindBackLinks:
         link_doc = DocumentWithLinkForNesting(link=back_link_doc, s="TEST")
         await link_doc.insert()
 
-        doc = await DocumentWithLinkForNesting.get(
-            link_doc.id, fetch_links=True
-        )
+        doc = await DocumentWithLinkForNesting.get(link_doc.id, fetch_links=True)
         assert isinstance(doc.link, Link)
         doc.link = await doc.link.fetch()
         assert doc.link.i == 1
 
-        back_link_doc = await DocumentWithBackLinkForNesting.get(
-            back_link_doc.id, fetch_links=True
-        )
-        assert (
-            back_link_doc.back_link.link.back_link.link.back_link.id
-            == link_doc.id
-        )
-        assert isinstance(
-            back_link_doc.back_link.link.back_link.link.back_link.link, Link
-        )
+        back_link_doc = await DocumentWithBackLinkForNesting.get(back_link_doc.id, fetch_links=True)
+        assert back_link_doc.back_link.link.back_link.link.back_link.id == link_doc.id
+        assert isinstance(back_link_doc.back_link.link.back_link.link.back_link.link, Link)
 
 
 class TestReplaceBackLinks:
     async def test_do_nothing(self, link_and_backlink_doc_pair):
-        link_doc, back_link_doc = link_and_backlink_doc_pair
+        _link_doc, back_link_doc = link_and_backlink_doc_pair
         back_link_doc.back_link.s = "new value"
         await back_link_doc.replace()
-        new_back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         assert new_back_link_doc.back_link.s == "TEST"
 
     async def test_do_nothing_list(self, list_link_and_list_backlink_doc_pair):
-        link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
-        back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        _link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
+        back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in back_link_doc.back_link:
             lnk.s = "new value"
         await back_link_doc.replace()
-        new_back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in new_back_link_doc.back_link:
             assert lnk.s == "TEST"
 
     async def test_write(self, link_and_backlink_doc_pair):
-        link_doc, back_link_doc = link_and_backlink_doc_pair
-        back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        _link_doc, back_link_doc = link_and_backlink_doc_pair
+        back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         back_link_doc.back_link.s = "new value"
         await back_link_doc.replace(link_rule=WriteRules.WRITE)
-        new_back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         assert new_back_link_doc.back_link.s == "new value"
 
-    async def test_do_nothing_write_list(
-        self, list_link_and_list_backlink_doc_pair
-    ):
-        link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
-        back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+    async def test_do_nothing_write_list(self, list_link_and_list_backlink_doc_pair):
+        _link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
+        back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in back_link_doc.back_link:
             lnk.s = "new value"
         await back_link_doc.replace(link_rule=WriteRules.WRITE)
-        new_back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in new_back_link_doc.back_link:
             assert lnk.s == "new value"
 
 
 class TestSaveBackLinks:
     async def test_do_nothing(self, link_and_backlink_doc_pair):
-        link_doc, back_link_doc = link_and_backlink_doc_pair
+        _link_doc, back_link_doc = link_and_backlink_doc_pair
         back_link_doc.back_link.s = "new value"
         await back_link_doc.save()
-        new_back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         assert new_back_link_doc.back_link.s == "TEST"
 
     async def test_do_nothing_list(self, list_link_and_list_backlink_doc_pair):
-        link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
-        back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        _link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
+        back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in back_link_doc.back_link:
             lnk.s = "new value"
         await back_link_doc.save()
-        new_back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in new_back_link_doc.back_link:
             assert lnk.s == "TEST"
 
     async def test_write(self, link_and_backlink_doc_pair):
-        link_doc, back_link_doc = link_and_backlink_doc_pair
-        back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        _link_doc, back_link_doc = link_and_backlink_doc_pair
+        back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         back_link_doc.back_link.s = "new value"
         await back_link_doc.save(link_rule=WriteRules.WRITE)
-        new_back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         assert new_back_link_doc.back_link.s == "new value"
 
     async def test_write_list(self, list_link_and_list_backlink_doc_pair):
-        link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
-        back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        _link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
+        back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in back_link_doc.back_link:
             lnk.s = "new value"
         await back_link_doc.save(link_rule=WriteRules.WRITE)
-        new_back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        new_back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         for lnk in new_back_link_doc.back_link:
             assert lnk.s == "new value"
 
@@ -846,7 +749,7 @@ class TestSaveBackLinks:
 class HouseForReversedOrderInit(Document):
     name: str
     door: Link["DoorForReversedOrderInit"]
-    owners: List[Link["PersonForReversedOrderInit"]]
+    owners: list[Link["PersonForReversedOrderInit"]]
 
 
 class DoorForReversedOrderInit(Document):
@@ -857,68 +760,46 @@ class DoorForReversedOrderInit(Document):
             json_schema_extra={"original_field": "door"}
         )
     else:
-        house: BackLink[HouseForReversedOrderInit] = Field(
-            original_field="door"
-        )
+        house: BackLink[HouseForReversedOrderInit] = Field(original_field="door")
 
 
 class PersonForReversedOrderInit(Document):
     name: str
     if IS_PYDANTIC_V2:
-        house: List[BackLink[HouseForReversedOrderInit]] = Field(
+        house: list[BackLink[HouseForReversedOrderInit]] = Field(
             json_schema_extra={"original_field": "owners"}
         )
     else:
-        house: List[BackLink[HouseForReversedOrderInit]] = Field(
-            original_field="owners"
-        )
+        house: list[BackLink[HouseForReversedOrderInit]] = Field(original_field="owners")
 
 
 class TestDeleteBackLinks:
     async def test_do_nothing(self, link_and_backlink_doc_pair):
         link_doc, back_link_doc = link_and_backlink_doc_pair
-        back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         await back_link_doc.delete()
-        new_link_doc = await DocumentWithLink.get(
-            link_doc.id, fetch_links=True
-        )
+        new_link_doc = await DocumentWithLink.get(link_doc.id, fetch_links=True)
         assert new_link_doc is not None
 
     async def test_do_nothing_list(self, list_link_and_list_backlink_doc_pair):
         link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
-        back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         await back_link_doc.delete()
-        new_link_doc = await DocumentWithListLink.get(
-            link_doc.id, fetch_links=True
-        )
+        new_link_doc = await DocumentWithListLink.get(link_doc.id, fetch_links=True)
         assert new_link_doc is not None
 
     async def test_delete_links(self, link_and_backlink_doc_pair):
         link_doc, back_link_doc = link_and_backlink_doc_pair
-        back_link_doc = await DocumentWithBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        back_link_doc = await DocumentWithBackLink.get(back_link_doc.id, fetch_links=True)
         await back_link_doc.delete(link_rule=DeleteRules.DELETE_LINKS)
-        new_link_doc = await DocumentWithLink.get(
-            link_doc.id, fetch_links=True
-        )
+        new_link_doc = await DocumentWithLink.get(link_doc.id, fetch_links=True)
         assert new_link_doc is None
 
-    async def test_delete_links_list(
-        self, list_link_and_list_backlink_doc_pair
-    ):
+    async def test_delete_links_list(self, list_link_and_list_backlink_doc_pair):
         link_doc, back_link_doc = list_link_and_list_backlink_doc_pair
-        back_link_doc = await DocumentWithListBackLink.get(
-            back_link_doc.id, fetch_links=True
-        )
+        back_link_doc = await DocumentWithListBackLink.get(back_link_doc.id, fetch_links=True)
         await back_link_doc.delete(link_rule=DeleteRules.DELETE_LINKS)
-        new_link_doc = await DocumentWithListLink.get(
-            link_doc.id, fetch_links=True
-        )
+        new_link_doc = await DocumentWithListLink.get(link_doc.id, fetch_links=True)
         assert new_link_doc is None
 
     async def test_init_reversed_order(self, db):
@@ -949,9 +830,7 @@ class TestBuildAggregations:
 
     async def test_find_aggregate_with_fetch_links(self, houses):
         door = await Door.find_one()
-        aggregation = House.find(
-            House.door.id == door.id, fetch_links=True
-        ).aggregate(
+        aggregation = House.find(House.door.id == door.id, fetch_links=True).aggregate(
             [
                 {"$group": {"_id": "$height", "count": {"$sum": 1}}},
             ]

--- a/tests/odm/test_state_management.py
+++ b/tests/odm/test_state_management.py
@@ -94,13 +94,8 @@ async def house(house_not_inserted):
 
 class TestStateManagement:
     async def test_use_state_management_property(self):
-        assert (
-            DocumentWithTurnedOnStateManagement.use_state_management() is True
-        )
-        assert (
-            DocumentWithTurnedOffStateManagement.use_state_management()
-            is False
-        )
+        assert DocumentWithTurnedOnStateManagement.use_state_management() is True
+        assert DocumentWithTurnedOffStateManagement.use_state_management() is False
 
     async def test_state_with_decimal_field(
         self,
@@ -205,9 +200,7 @@ class TestStateManagement:
                 doc.is_changed
 
         async def test_state_management_on_not_changed(self):
-            doc = DocumentWithTurnedOnStateManagement(
-                num_1=1, num_2=2, internal=InternalDoc()
-            )
+            doc = DocumentWithTurnedOnStateManagement(num_1=1, num_2=2, internal=InternalDoc())
 
             with pytest.raises(StateNotSaved):
                 doc.is_changed
@@ -227,17 +220,13 @@ class TestStateManagement:
                 doc.has_changed
 
         async def test_state_management_on_not_changed(self):
-            doc = DocumentWithTurnedOnStateManagement(
-                num_1=1, num_2=2, internal=InternalDoc()
-            )
+            doc = DocumentWithTurnedOnStateManagement(num_1=1, num_2=2, internal=InternalDoc())
 
             with pytest.raises(StateNotSaved):
                 doc.has_changed
 
         async def test_save_previous_on_not_changed(self):
-            doc = DocumentWithTurnedOnSavePrevious(
-                num_1=1, num_2=2, internal=InternalDoc()
-            )
+            doc = DocumentWithTurnedOnSavePrevious(num_1=1, num_2=2, internal=InternalDoc())
 
             with pytest.raises(StateNotSaved):
                 doc.has_changed
@@ -327,21 +316,15 @@ class TestStateManagement:
             saved_doc_default.num_1 = 10000
 
             saved_doc_default.internal.change_private()
-            assert (
-                saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
-            )
+            assert saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
 
             await saved_doc_default.save_changes()
 
             assert saved_doc_default.get_saved_state()["num_1"] == 10000
             assert saved_doc_default.get_previous_saved_state() is None
-            assert (
-                saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
-            )
+            assert saved_doc_default.internal.get_private() == "PRIVATE_CHANGED"
 
-            new_doc = await DocumentWithTurnedOnStateManagement.get(
-                saved_doc_default.id
-            )
+            new_doc = await DocumentWithTurnedOnStateManagement.get(saved_doc_default.id)
             assert new_doc.num_1 == 10000
 
         async def test_save_changes_previous(self, saved_doc_previous):
@@ -351,20 +334,14 @@ class TestStateManagement:
             saved_doc_previous.num_1 = 10000
 
             saved_doc_previous.internal.change_private()
-            assert (
-                saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
-            )
+            assert saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
 
             await saved_doc_previous.save_changes()
             assert saved_doc_previous.get_saved_state()["num_1"] == 10000
             assert saved_doc_previous.get_previous_saved_state()["num_1"] == 1
-            assert (
-                saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
-            )
+            assert saved_doc_previous.internal.get_private() == "PRIVATE_CHANGED"
 
-            new_doc = await DocumentWithTurnedOnSavePrevious.get(
-                saved_doc_previous.id
-            )
+            new_doc = await DocumentWithTurnedOnSavePrevious.get(saved_doc_previous.id)
             assert new_doc.num_1 == 10000
 
         async def test_fetch_save_changes(self, house):
@@ -376,9 +353,7 @@ class TestStateManagement:
             await window_0.save_changes()
 
         async def test_find_one(self, saved_doc_default, state):
-            new_doc = await DocumentWithTurnedOnStateManagement.get(
-                saved_doc_default.id
-            )
+            new_doc = await DocumentWithTurnedOnStateManagement.get(saved_doc_default.id)
             assert new_doc.get_saved_state() == state
             assert new_doc.get_previous_saved_state() is None
 
@@ -407,9 +382,7 @@ class TestStateManagement:
                 assert doc.get_previous_saved_state() is None
 
         async def test_insert(self, state_without_id):
-            doc = parse_model(
-                DocumentWithTurnedOnStateManagement, state_without_id
-            )
+            doc = parse_model(DocumentWithTurnedOnStateManagement, state_without_id)
             assert doc.get_saved_state() is None
             await doc.insert()
             new_state = doc.get_saved_state()
@@ -438,25 +411,8 @@ class TestStateManagement:
             assert saved_doc_previous.get_saved_state()["num_1"] == 100
             assert saved_doc_previous.get_previous_saved_state()["num_1"] == 1
 
-            assert (
-                saved_doc_previous.get_saved_state().get("revision_id") is None
-            )
-            assert (
-                saved_doc_previous.get_saved_state().get(
-                    "previous_revision_id"
-                )
-                is None
-            )
+            assert saved_doc_previous.get_saved_state().get("revision_id") is None
+            assert saved_doc_previous.get_saved_state().get("previous_revision_id") is None
 
-            assert (
-                saved_doc_previous.get_previous_saved_state().get(
-                    "revision_id"
-                )
-                is None
-            )
-            assert (
-                saved_doc_previous.get_previous_saved_state().get(
-                    "previous_revision_id"
-                )
-                is None
-            )
+            assert saved_doc_previous.get_previous_saved_state().get("revision_id") is None
+            assert saved_doc_previous.get_previous_saved_state().get("previous_revision_id") is None

--- a/tests/odm/test_timesries_collection.py
+++ b/tests/odm/test_timesries_collection.py
@@ -11,14 +11,10 @@ async def test_timeseries_collection(db):
     major_version = int(mongo_version.split(".")[0])
     if major_version < 5:
         with pytest.raises(MongoDBVersionError):
-            await init_beanie(
-                database=db, document_models=[DocumentWithTimeseries]
-            )
+            await init_beanie(database=db, document_models=[DocumentWithTimeseries])
 
     if major_version >= 5:
-        await init_beanie(
-            database=db, document_models=[DocumentWithTimeseries]
-        )
+        await init_beanie(database=db, document_models=[DocumentWithTimeseries])
         info = await db.command(
             {
                 "listCollections": 1,

--- a/tests/odm/test_typing_utils.py
+++ b/tests/odm/test_typing_utils.py
@@ -1,8 +1,7 @@
-from typing import Optional, Union
+from typing import Annotated, Optional, Union
 
 import pytest
 from pydantic import BaseModel
-from typing_extensions import Annotated
 
 from beanie import Document, Link
 from beanie.odm.fields import Indexed

--- a/tests/typing/aggregation.py
+++ b/tests/typing/aggregation.py
@@ -1,21 +1,15 @@
-from typing import Any, Dict, List
+from typing import Any
 
 from tests.typing.models import ProjectionTest, Test
 
 
-async def aggregate() -> List[Dict[str, Any]]:
+async def aggregate() -> list[dict[str, Any]]:
     result = await Test.aggregate([]).to_list()
     result_2 = await Test.find().aggregate([]).to_list()
     return result or result_2
 
 
-async def aggregate_with_projection() -> List[ProjectionTest]:
-    result = (
-        await Test.find()
-        .aggregate([], projection_model=ProjectionTest)
-        .to_list()
-    )
-    result_2 = await Test.aggregate(
-        [], projection_model=ProjectionTest
-    ).to_list()
+async def aggregate_with_projection() -> list[ProjectionTest]:
+    result = await Test.find().aggregate([], projection_model=ProjectionTest).to_list()
+    result_2 = await Test.aggregate([], projection_model=ProjectionTest).to_list()
     return result or result_2

--- a/tests/typing/decorators.py
+++ b/tests/typing/decorators.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Coroutine
+from collections.abc import Coroutine
+from typing import Any, Callable
 
 from typing_extensions import Protocol, TypeAlias, assert_type
 
@@ -29,9 +30,7 @@ async def async_func(doc_self: Document, arg1: str, arg2: int, /) -> Document:
     raise NotImplementedError
 
 
-AsyncFunc: TypeAlias = Callable[
-    [Document, str, int], Coroutine[Any, Any, Document]
-]
+AsyncFunc: TypeAlias = Callable[[Document, str, int], Coroutine[Any, Any, Document]]
 
 
 def test_wrap_with_actions_preserves_signature() -> None:

--- a/tests/typing/find.py
+++ b/tests/typing/find.py
@@ -1,25 +1,25 @@
-from typing import List, Optional
+from typing import Optional
 
 from tests.typing.models import ProjectionTest, Test
 
 
-async def find_many() -> List[Test]:
+async def find_many() -> list[Test]:
     return await Test.find().to_list()
 
 
-async def find_many_with_projection() -> List[ProjectionTest]:
+async def find_many_with_projection() -> list[ProjectionTest]:
     return await Test.find().project(projection_model=ProjectionTest).to_list()
 
 
-async def find_many_generator() -> List[Test]:
-    docs: List[Test] = []
+async def find_many_generator() -> list[Test]:
+    docs: list[Test] = []
     async for doc in Test.find():
         docs.append(doc)
     return docs
 
 
-async def find_many_generator_with_projection() -> List[ProjectionTest]:
-    docs: List[ProjectionTest] = []
+async def find_many_generator_with_projection() -> list[ProjectionTest]:
+    docs: list[ProjectionTest] = []
     async for doc in Test.find().project(projection_model=ProjectionTest):
         docs.append(doc)
     return docs


### PR DESCRIPTION
Codebase modernization after removal of Python 3.8 support:

* Removed future annotations imports.
* Set maximum line length to 100 from 79.
* Re-formatted all files due to above change.
* Enabled more Ruff rules (most notably pyupgrade - "UP").
* Fixed "RUF029" rule violation in tests.
* Minor docstring fixes.
* Introduced is_generic_alias() to beanie.odm.utils.typing module. Provides better support for both new generic types and older generic types from the typing module (e.g. typing.List[str]).

Closes #824 