### PR TITLE
Update encoder.py

### DIFF
--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -159,11 +159,11 @@ class Encoder:
 
         obj_iter_keys = obj.__iter__.keys()
         if IS_PYDANTIC_V2:
-            if obj.__class__.model_config.get('extra') != 'allow':
+            if obj.__class__.model_config.get("extra") != "allow":
                 model_class = obj.__class__
                 obj_iter_keys = list(model_class.model_fields.keys()) + list(
                     model_class.model_computed_fields.keys()
-                )                           
+                )
 
         for key, value in obj.__iter__():
             if key in obj_iter_keys:

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -162,6 +162,8 @@ class Encoder:
             obj_iter_keys = list(model_class.model_fields.keys()) + list(
                 model_class.model_computed_fields.keys()
             )
+        else:
+            obj_iter_keys = obj.__iter__.keys()        
 
         for key, value in obj.__iter__():
             if key in obj_iter_keys:

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -156,7 +156,7 @@ class Encoder:
         get_model_field = get_model_fields(obj).get
 
         if IS_PYDANTIC_V2:
-            model_class = obj.__class__``
+            model_class = obj.__class__
             if model_class.model_config.get("extra") != "allow":
                 obj_iter_keys = set(model_class.model_fields.keys()) | set(
                 model_class.model_computed_fields.keys()

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -157,14 +157,13 @@ class Encoder:
         exclude, keep_nulls = self.exclude, self.keep_nulls
         get_model_field = get_model_fields(obj).get
 
+        obj_iter_keys = obj.__iter__.keys()
         if IS_PYDANTIC_V2:
             if obj.__class__.model_config.get('extra') != 'allow':
                 model_class = obj.__class__
                 obj_iter_keys = list(model_class.model_fields.keys()) + list(
                     model_class.model_computed_fields.keys()
-                )
-        else:
-            obj_iter_keys = obj.__iter__.keys()        
+                )                           
 
         for key, value in obj.__iter__():
             if key in obj_iter_keys:

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -158,10 +158,11 @@ class Encoder:
         get_model_field = get_model_fields(obj).get
 
         if IS_PYDANTIC_V2:
-            model_class = obj.__class__
-            obj_iter_keys = list(model_class.model_fields.keys()) + list(
-                model_class.model_computed_fields.keys()
-            )
+            if obj.__class__.model_config.get('extra') != 'allow':
+                model_class = obj.__class__
+                obj_iter_keys = list(model_class.model_fields.keys()) + list(
+                    model_class.model_computed_fields.keys()
+                )
         else:
             obj_iter_keys = obj.__iter__.keys()        
 

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -151,7 +151,9 @@ class Encoder:
 
         raise ValueError(f"Cannot encode {obj!r}")
 
-    def _iter_model_items(self, obj: pydantic.BaseModel) -> Iterable[Tuple[str, Any]]:
+    def _iter_model_items(
+        self, obj: pydantic.BaseModel
+    ) -> Iterable[Tuple[str, Any]]:
         exclude, keep_nulls = self.exclude, self.keep_nulls
         get_model_field = get_model_fields(obj).get
 
@@ -159,18 +161,20 @@ class Encoder:
             model_class = obj.__class__
             if model_class.model_config.get("extra") != "allow":
                 obj_iter_keys = set(model_class.model_fields.keys()) | set(
-                model_class.model_computed_fields.keys()
-            )
+                    model_class.model_computed_fields.keys()
+                )
             else:
                 obj_iter_keys = {k for k, _ in obj.__iter__()}
         else:
             obj_iter_keys = {k for k, _ in obj.__iter__()}
-    
+
         for key, value in obj.__iter__():
             if key in obj_iter_keys:
                 field_info = get_model_field(key)
                 out_key = field_info.alias or key if field_info else key
-                if out_key not in exclude and (value is not None or keep_nulls):
+                if out_key not in exclude and (
+                    value is not None or keep_nulls
+                ):
                     yield out_key, value
 
 

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -159,7 +159,9 @@ class Encoder:
 
         if IS_PYDANTIC_V2:
             model_class = obj.__class__
-            obj_iter_keys = list(model_class.model_fields.keys()) + list(model_class.model_computed_fields.keys())
+            obj_iter_keys = list(model_class.model_fields.keys()) + list(
+                model_class.model_computed_fields.keys()
+            )
 
         for key, value in obj.__iter__():
             if key in obj_iter_keys:

--- a/beanie/odm/utils/encoder.py
+++ b/beanie/odm/utils/encoder.py
@@ -156,12 +156,18 @@ class Encoder:
     ) -> Iterable[Tuple[str, Any]]:
         exclude, keep_nulls = self.exclude, self.keep_nulls
         get_model_field = get_model_fields(obj).get
+
+        if IS_PYDANTIC_V2:
+            model_class = obj.__class__
+            obj_iter_keys = list(model_class.model_fields.keys()) + list(model_class.model_computed_fields.keys())
+
         for key, value in obj.__iter__():
-            field_info = get_model_field(key)
-            if field_info is not None:
-                key = field_info.alias or key
-            if key not in exclude and (value is not None or keep_nulls):
-                yield key, value
+            if key in obj_iter_keys:
+                field_info = get_model_field(key)
+                if field_info is not None:
+                    key = field_info.alias or key
+                if key not in exclude and (value is not None or keep_nulls):
+                    yield key, value
 
 
 def _get_encoder(


### PR DESCRIPTION
The current encoder method iterates through obj.iter. However this captures class properties that are not explicitly defined in the base model as a field (or as a computed field).

This can cause bugs where a user has a property that is not encodable [and was not meant to be a field in the Document].

I limited it to only used keys that are set as fields or computed fields.