### PR TITLE
fix: incomplete type hint for Regex pattern

### DIFF
--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -100,10 +100,8 @@ class RegEx(BaseFindEvaluationOperator):
     def __init__(
         self,
         field,
-        pattern: str,
-        options: Optional[
-            Union[str, re.Pattern[bytes], re.Pattern[str]]
-        ] = None,
+        pattern: Union[str, re.Pattern[bytes], re.Pattern[str]],
+        options: Optional[str] = None,
     ):
         self.field = field
         self.pattern = pattern
@@ -180,9 +178,7 @@ class Text(BaseFindEvaluationOperator):
         if self.language:
             expression["$text"]["$language"] = self.language
         if self.diacritic_sensitive is not None:
-            expression["$text"]["$diacriticSensitive"] = (
-                self.diacritic_sensitive
-            )
+            expression["$text"]["$diacriticSensitive"] = self.diacritic_sensitive
         return expression
 
 

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABC
-from typing import Optional, Union
+from typing import AnyStr, Optional, Union
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -100,7 +100,7 @@ class RegEx(BaseFindEvaluationOperator):
     def __init__(
         self,
         field,
-        pattern: Union[str, re.Pattern[Union[bytes, str]]],
+        options: Optional[Union[str, re.Pattern[AnyStr]]] = None,
         options: Optional[str] = None,
     ):
         self.field = field

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -178,7 +178,9 @@ class Text(BaseFindEvaluationOperator):
         if self.language:
             expression["$text"]["$language"] = self.language
         if self.diacritic_sensitive is not None:
-            expression["$text"]["$diacriticSensitive"] = self.diacritic_sensitive
+            expression["$text"]["$diacriticSensitive"] = (
+                self.diacritic_sensitive
+            )
         return expression
 
 

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -1,5 +1,6 @@
+import re
 from abc import ABC
-from typing import Optional
+from typing import Optional, Union
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -99,7 +100,7 @@ class RegEx(BaseFindEvaluationOperator):
     def __init__(
         self,
         field,
-        pattern: str,
+        pattern: Union[str, re.Pattern[str]],
         options: Optional[str] = None,
     ):
         self.field = field

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABC
-from typing import AnyStr, Optional, Union
+from typing import Optional, Union
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -101,7 +101,9 @@ class RegEx(BaseFindEvaluationOperator):
         self,
         field,
         pattern: str,
-        options: Optional[Union[str, re.Pattern[AnyStr]]] = None,
+        options: Optional[
+            Union[str, re.Pattern[bytes], re.Pattern[str]]
+        ] = None,
     ):
         self.field = field
         self.pattern = pattern

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -101,7 +101,6 @@ class RegEx(BaseFindEvaluationOperator):
         self,
         field,
         options: Optional[Union[str, re.Pattern[AnyStr]]] = None,
-        options: Optional[str] = None,
     ):
         self.field = field
         self.pattern = pattern

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -100,6 +100,7 @@ class RegEx(BaseFindEvaluationOperator):
     def __init__(
         self,
         field,
+        pattern: str,
         options: Optional[Union[str, re.Pattern[AnyStr]]] = None,
     ):
         self.field = field

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -100,7 +100,7 @@ class RegEx(BaseFindEvaluationOperator):
     def __init__(
         self,
         field,
-        pattern: Union[str, re.Pattern[AnyStr]],
+        pattern: Union[str, re.Pattern[Union[bytes, str]]],
         options: Optional[str] = None,
     ):
         self.field = field

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -100,7 +100,7 @@ class RegEx(BaseFindEvaluationOperator):
     def __init__(
         self,
         field,
-        pattern: Union[str, re.Pattern]],
+        pattern: Union[str, re.Pattern[AnyStr]],
         options: Optional[str] = None,
     ):
         self.field = field

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -100,7 +100,7 @@ class RegEx(BaseFindEvaluationOperator):
     def __init__(
         self,
         field,
-        pattern: Union[str, re.Pattern[str]],
+        pattern: Union[str, re.Pattern]],
         options: Optional[str] = None,
     ):
         self.field = field


### PR DESCRIPTION

Beanie's `Regex` Class can use `re.Pattern[str]` as `pattern`. In the background, `bson.regex.Regex` 's `.from_native` method support it. So I add it to type hint. 

In exist tests, we also can see that: https://github.com/BeanieODM/beanie/blob/53123ce17cb09613b0bb01a5e8ba3ab24b3e872e/tests/odm/test_encoder.py#L49-L55


<img width="695" height="435" alt="image" src="https://github.com/user-attachments/assets/e4c454ff-3adc-4a5b-b4b8-fc2da8764c4f" />
