### PR TITLE
Do not raise DeprecationWarning internally when accessing `bucket_rounding_second` deprecated field

### DIFF
--- a/beanie/odm/settings/timeseries.py
+++ b/beanie/odm/settings/timeseries.py
@@ -36,17 +36,26 @@ class TimeSeriesConfig(BaseModel):
     def build_query(self, collection_name: str) -> Dict[str, Any]:
         res: Dict[str, Any] = {"name": collection_name}
         timeseries: Dict[str, Any] = {"timeField": self.time_field}
+
         if self.meta_field is not None:
             timeseries["metaField"] = self.meta_field
         if self.granularity is not None:
             timeseries["granularity"] = self.granularity
         if self.bucket_max_span_seconds is not None:
             timeseries["bucketMaxSpanSeconds"] = self.bucket_max_span_seconds
-        if self.bucket_rounding_second is not None:  # Deprecated field
-            timeseries["bucketRoundingSeconds"] = self.bucket_rounding_second
-        if self.bucket_rounding_seconds is not None:
-            timeseries["bucketRoundingSeconds"] = self.bucket_rounding_seconds
+
+        # Use new field if present, otherwise fallback to deprecated one without triggering warning
+        rounding = self.bucket_rounding_seconds
+        if rounding is None:
+            # Avoid deprecation warning by checking __dict__ directly
+            rounding = self.__dict__.get("bucket_rounding_second")
+
+        if rounding is not None:
+            timeseries["bucketRoundingSeconds"] = rounding
+
         res["timeseries"] = timeseries
+
         if self.expire_after_seconds is not None:
             res["expireAfterSeconds"] = self.expire_after_seconds
+
         return res


### PR DESCRIPTION
Beanie internally triggered a DeprecationWarning in the code that handled backwards compatibility for the `bucket_rounding_second` deprecated field in the `TimeSeriesConfig` class.
This PR fixes that issue.