### PR TITLE
Version/2.0.1

### DIFF
--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -37,7 +37,7 @@ from beanie.odm.union_doc import UnionDoc
 from beanie.odm.utils.init import init_beanie
 from beanie.odm.views import View
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __all__ = [
     # ODM
     "Document",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,34 @@
 
 Beanie project
 
+## [2.0.1] - 2025-11-17
+### Fix: exclude pymongo 4.15.0 due to a known issue
+- Author - [staticxterm](https://github.com/staticxterm)
+- PR <https://github.com/BeanieODM/beanie/pull/1225>
+### Bump lazy-model
+- Author - [CAPITAINMARVEL](https://github.com/CAPITAINMARVEL)
+- PR <https://github.com/BeanieODM/beanie/pull/1218>
+### Fix: incomplete type hint for regex pattern
+- Author - [xcrong](https://github.com/xcrong)
+- PR <https://github.com/BeanieODM/beanie/pull/1209>
+### Fix return types of min and max methods
+- Author - [kewldan](https://github.com/kewldan)
+- PR <https://github.com/BeanieODM/beanie/pull/1204>
+### Handle aggregation method on the whole collection
+- Author - [CAPITAINMARVEL](https://github.com/CAPITAINMARVEL)
+- PR <https://github.com/BeanieODM/beanie/pull/1203>
+### Fix: preserve fetch_links across chained find() and find_one()
+- Author - [scarlet2131](https://github.com/scarlet2131)
+- PR <https://github.com/BeanieODM/beanie/pull/1184>
+### Fix: pydantic "exclude" option is not working #756
+- Author - [CatBraaain](https://github.com/CatBraaain)
+- PR <https://github.com/BeanieODM/beanie/pull/1154>
+### Fix pydanticdeprecatedsince211: accessing the 'model_fields' attribute on the instance is deprecated
+- Author - [gsakkis](https://github.com/gsakkis)
+- PR <https://github.com/BeanieODM/beanie/pull/1150>
+
+[2.0.1]: https://pypi.org/project/beanie/2.0.1
+
 ## [2.0.0] - 2025-07-09
 ### Transform asyncdocmethod[doctype, p, r] into any to fix "incorrect call arguments" warning in pycharm
 - Author - [hRtWzFe](https://github.com/hRtWzFe)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "beanie"
-version = "2.0.0"
+version = "2.0.1"
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9,<3.14"
 license = { file="LICENSE" }
 authors = [
     {name = "Roman Right", email = "roman-right@protonmail.com"}
@@ -21,6 +21,14 @@ classifiers = [
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "pydantic>=1.10.18,<3.0",
@@ -69,7 +77,7 @@ zstd = ["pymongo[zstd]>=4.11.0,!=4.15.0,<5.0.0"]
 
 [project.urls]
 homepage = "https://beanie-odm.dev"
-repository = "https://github.com/roman-right/beanie"
+repository = "https://github.com/BeanieODM/beanie"
 
 [project.scripts]
 beanie = "beanie.executors.migrate:migrations"

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -80,8 +80,8 @@ if __name__ == "__main__":
     generator = ChangelogGenerator(
         username="BeanieODM",
         repository="beanie",
-        current_version="1.30.0",
-        new_version="2.0.0",
+        current_version="2.0.0",
+        new_version="2.0.1",
     )
 
     changelog = generator.generate_changelog()


### PR DESCRIPTION
Next patch release of Beanie.
Changes in this release PR:
* Limit last supported major version of Python to 3.13.
* Add "trove classifiers" stating known supported Python versions.
* Update Beanie main repository in "[project.urls]".