### PR TITLE
filter first other than materializing refs

### DIFF
--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -647,7 +647,7 @@ class FindMany(
                             if len(non_text_queries) > 1
                             else non_text_queries[0]
                         )
-                    }
+                    },
                 )
 
         if extra_stages:


### PR DESCRIPTION
filter query should be executed before lookup of all the references for finding. The previous implementation had two issues
1. slower execution due to matching in a later stage
2. field mismatch after transformation especially with an array of Links as a query.


EDIT: I have not updated the test cases, but wonder if it was intended or this fix would be acceptable. I'd be happy to complete fixing all the tests.