### PR TITLE
feat: Support Python 3.14

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -7,11 +7,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         # 5.0: kept for AWS DocumentDB / Azure DocumentDB compatibility
         # 7.0, 8.0: current supported MongoDB releases
         mongodb-version: [ "5.0", "7.0", "8.0" ]
         pydantic-version: [ "2.11", "2.12" ]
+        exclude:
+          - python-version: "3.14"
+            pydantic-version: "2.11"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/beanie/migrations/controllers/iterative.py
+++ b/beanie/migrations/controllers/iterative.py
@@ -1,4 +1,5 @@
 import asyncio
+import typing
 from collections.abc import Callable
 from inspect import isclass, signature
 from typing import Any
@@ -53,17 +54,19 @@ def iterative_migration(
             )
             if input_signature is None:
                 raise RuntimeError("input_signature must not be None")
-            self.input_document_model: type[Document] = (
-                input_signature.annotation
-            )
             output_signature = self.function_signature.parameters.get(
                 "output_document"
             )
             if output_signature is None:
                 raise RuntimeError("output_signature must not be None")
-            self.output_document_model: type[Document] = (
-                output_signature.annotation
-            )
+
+            # Use get_type_hints() to resolve annotations properly,
+            # including deferred annotations on Python 3.14+.
+            hints = typing.get_type_hints(function)
+            self.input_document_model: type[Document] = hints["input_document"]
+            self.output_document_model: type[Document] = hints[
+                "output_document"
+            ]
 
             if (
                 not isclass(self.input_document_model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "beanie"
 version = "2.1.0"
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10"
 license = { file="LICENSE" }
 authors = [
     {name = "Roman Right", email = "roman-right@protonmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "beanie"
 version = "2.1.0"
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 license = { file="LICENSE" }
 authors = [
     {name = "Roman Right", email = "roman-right@protonmail.com"}
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "pydantic>=2.4,<3.0",


### PR DESCRIPTION
## Summary
 
Add support for Python 3.14 version to the test matrix and dependency bounds.

### Added
|  Dependency | Added  | Reason |
|---|---|---|
| Python 3.14  | Yes  | Released October 7, 2025 |

### Excluded
| Dependencies | Excluded | Reason
|---|---|---|
| Python 3.14 + Pydantic 2.11 | Yes | Pydantic 2.11 doesn't support Python 3.14
 
### New matrix
| Python | MongoDB | Pydantic |
|---|---|---|
| 3.10, 3.11, 3.12, 3.13, 3.14 | 5.0, 7.0, 8.0 | 2.11 (excluded for Python 3.14), 2.12 |
 
 CI jobs per PR: **27** (was 24).

### Changes
 
* `.github/workflows/github-actions-tests.yml`: updated matrix, added Python 3.14
* `pyproject.toml`: `requires-python = ">=3.10,<3.15"`, added Python 3.14 classifier
* `beanie/migrations/controllers/free_fall.py` and `beanie/migrations/controllers/iterative.py`: add support for new `inspect.signature` with [PEP 649](https://peps.python.org/pep-0649/) & [PEP 749](https://peps.python.org/pep-0749/): [Deferred evaluation of annotations](https://docs.python.org/3/whatsnew/3.14.html#whatsnew314-deferred-annotations)
 
 
### Notes
 
* This mainly only changes the CI matrix and metadata. Added support of _Deferred evaluation of annotations_ to make sure new annotations do not break migrations.

