### PR TITLE
perf(tests): significantly improve test execution time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ test = [
     "pydantic-settings>=2",
     "pydantic-extra-types>=2",
     "pydantic[email]",
+    "time-machine>=3.2.0"
 ]
 doc = [
     "Pygments>=2.8.0",
@@ -111,7 +112,8 @@ filterwarnings = [
     "ignore::UserWarning",
 ]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 
 [tool.beanie.migrations]
 path = "beanie/example_migration"
@@ -143,6 +145,9 @@ exclude = [
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 120
 
+[tool.ruff.lint.flake8-pytest-style]
+parametrize-names-type = "csv"
+
 [tool.ruff.lint]
 preview = true
 select =  [
@@ -160,7 +165,9 @@ select =  [
     # flake8-simplify
     "SIM",
     # Ruff specific
-    "RUF"
+    "RUF",
+    # Pytest
+    "PT"
 ]
 ignore = [
     "E501",
@@ -178,7 +185,8 @@ ignore = [
     "SIM102",
     "SIM103",
     "SIM108",
-    "SIM118"
+    "SIM118",
+    "PT011"
 ]
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,12 @@ class Settings(BaseSettings):
     mongodb_db_name: str = "beanie_db"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def settings():
     return Settings()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 async def cli(settings):
     client = AsyncMongoClient(settings.mongodb_dsn)
 
@@ -22,6 +22,6 @@ async def cli(settings):
     await client.close()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def db(cli, settings):
     return cli[settings.mongodb_db_name]

--- a/tests/fastapi/conftest.py
+++ b/tests/fastapi/conftest.py
@@ -13,8 +13,8 @@ from tests.fastapi.models import (
 )
 
 
-@pytest.fixture(autouse=True)
-async def api_client(clean_db):
+@pytest.fixture
+async def api_client():
     """api client fixture."""
     async with LifespanManager(app, startup_timeout=100, shutdown_timeout=100):
         server_name = "http://localhost"

--- a/tests/migrations/iterative/test_change_subfield.py
+++ b/tests/migrations/iterative/test_change_subfield.py
@@ -34,7 +34,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[OldNote])
     await OldNote.delete_all()

--- a/tests/migrations/iterative/test_change_value.py
+++ b/tests/migrations/iterative/test_change_value.py
@@ -21,7 +21,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[Note])
     await Note.delete_all()

--- a/tests/migrations/iterative/test_change_value_subfield.py
+++ b/tests/migrations/iterative/test_change_value_subfield.py
@@ -21,7 +21,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[Note])
     await Note.delete_all()

--- a/tests/migrations/iterative/test_pack_unpack.py
+++ b/tests/migrations/iterative/test_pack_unpack.py
@@ -35,7 +35,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[OldNote])
     await OldNote.delete_all()

--- a/tests/migrations/iterative/test_rename_field.py
+++ b/tests/migrations/iterative/test_rename_field.py
@@ -29,7 +29,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[OldNote])
     await OldNote.delete_all()
@@ -37,7 +37,7 @@ async def notes(db):
         note = OldNote(name=str(i), tag=Tag(name="test", color="red"))
         await note.insert()
     yield
-    # await OldNote.delete_all()
+    await OldNote.delete_all()
 
 
 async def test_migration_rename_field(settings, notes, db):

--- a/tests/migrations/test_break.py
+++ b/tests/migrations/test_break.py
@@ -30,7 +30,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[OldNote])
     await OldNote.delete_all()

--- a/tests/migrations/test_directions.py
+++ b/tests/migrations/test_directions.py
@@ -20,7 +20,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[Note])
     await Note.delete_all()

--- a/tests/migrations/test_free_fall.py
+++ b/tests/migrations/test_free_fall.py
@@ -29,7 +29,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[OldNote])
     await OldNote.delete_all()

--- a/tests/migrations/test_remove_indexes.py
+++ b/tests/migrations/test_remove_indexes.py
@@ -28,7 +28,7 @@ class Note(Document):
         name = "notes"
 
 
-@pytest.fixture()
+@pytest.fixture
 async def notes(db):
     await init_beanie(database=db, document_models=[OldNote])
     await OldNote.delete_all()

--- a/tests/odm/conftest.py
+++ b/tests/odm/conftest.py
@@ -4,6 +4,7 @@ from random import randint
 
 import pytest
 
+from beanie.odm.documents import Document
 from beanie.odm.utils.init import init_beanie
 from tests.odm.models import (
     ADocument,
@@ -270,7 +271,7 @@ async def preset_documents(point):
     await Sample.insert_many(documents=docs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def sample_doc_not_saved(point):
     nested = Nested(
         integer=0,
@@ -312,7 +313,7 @@ def recwarn_always(recwarn):
     return recwarn
 
 
-@pytest.fixture()
+@pytest.fixture
 async def deprecated_init_beanie(db, recwarn_always):
     await init_beanie(
         database=db,
@@ -326,25 +327,45 @@ async def deprecated_init_beanie(db, recwarn_always):
         in str(recwarn_always[0].message)
     )
 
-    yield
-
-    for model in TESTING_MODELS:
-        await model.get_pymongo_collection().drop()
-        await model.get_pymongo_collection().drop_indexes()
+    return
 
 
 @pytest.fixture(autouse=True)
+async def clean_db():
+    async def _cleanup() -> None:
+        seen = set()
+        for model in TESTING_MODELS:
+            if not issubclass(model, Document):
+                continue
+
+            collection = model.get_pymongo_collection()
+            key = (collection.database.name, collection.name)
+
+            # Avoid cleaning the same shared collection multiple times
+            if key in seen:
+                continue
+            seen.add(key)
+
+            await collection.delete_many({})
+
+            # Reset model cache
+            cache = getattr(model, "_cache", None)
+            if cache is not None:
+                cache.cache.clear()
+
+    await _cleanup()
+    yield
+    await _cleanup()
+
+
+@pytest.fixture(scope="session", autouse=True)
 async def init(db):
     await init_beanie(
         database=db,
         document_models=TESTING_MODELS,
     )
 
-    yield
-
-    for model in TESTING_MODELS:
-        await model.get_pymongo_collection().drop()
-        await model.get_pymongo_collection().drop_indexes()
+    return
 
 
 @pytest.fixture

--- a/tests/odm/documents/test_bulk_write.py
+++ b/tests/odm/documents/test_bulk_write.py
@@ -72,7 +72,7 @@ async def test_unordered_update(documents, document):
     await documents(5)
     doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 0)
     doc.test_int = 100
-    with pytest.raises(BulkWriteError):
+    with pytest.raises(BulkWriteError):  # noqa: PT012
         async with BulkWriter(ordered=False) as bulk_writer:
             await DocumentTestModel.insert_one(
                 document, bulk_writer=bulk_writer
@@ -221,7 +221,7 @@ async def test_ordered_bulk(documents):
     doc = await DocumentMultiModelOne.insert_one(DocumentMultiModelOne())
     assert doc
     assert doc.id
-    with pytest.raises(BulkWriteError):
+    with pytest.raises(BulkWriteError):  # noqa: PT012
         async with BulkWriter(ordered=True) as bulk_writer:
             doc1 = DocumentMultiModelOne()
             doc1.id = doc.id

--- a/tests/odm/documents/test_init.py
+++ b/tests/odm/documents/test_init.py
@@ -78,10 +78,8 @@ async def test_metadata_connection_string(settings):
     )
 
     metadata = NewDocument.get_pymongo_collection().database.client.options.pool_options.metadata
-    assert (
-        "beanie" in metadata["driver"]["name"]
-        and beanie_version in metadata["driver"]["version"]
-    )
+    assert "beanie" in metadata["driver"]["name"]
+    assert beanie_version in metadata["driver"]["version"]
 
 
 @pytest.mark.skipif(
@@ -95,10 +93,8 @@ async def test_metadata_database(db):
     await init_beanie(database=db, document_models=[NewDocument])
 
     metadata = NewDocument.get_pymongo_collection().database.client.options.pool_options.metadata
-    assert (
-        "beanie" in metadata["driver"]["name"]
-        and beanie_version in metadata["driver"]["version"]
-    )
+    assert "beanie" in metadata["driver"]["name"]
+    assert beanie_version in metadata["driver"]["version"]
 
 
 def test_collection_with_custom_name():

--- a/tests/odm/documents/test_update.py
+++ b/tests/odm/documents/test_update.py
@@ -89,10 +89,8 @@ async def test_save(document):
 
 async def test_save_not_saved(document_not_inserted):
     await document_not_inserted.save()
-    assert (
-        hasattr(document_not_inserted, "id")
-        and document_not_inserted.id is not None
-    )
+    assert hasattr(document_not_inserted, "id")
+    assert document_not_inserted.id is not None
     from_db = await DocumentTestModel.get(document_not_inserted.id)
     assert from_db == document_not_inserted
 
@@ -100,10 +98,8 @@ async def test_save_not_saved(document_not_inserted):
 async def test_save_not_found(document_not_inserted):
     document_not_inserted.id = PydanticObjectId()
     await document_not_inserted.save()
-    assert (
-        hasattr(document_not_inserted, "id")
-        and document_not_inserted.id is not None
-    )
+    assert hasattr(document_not_inserted, "id")
+    assert document_not_inserted.id is not None
     from_db = await DocumentTestModel.get(document_not_inserted.id)
     assert from_db == document_not_inserted
 

--- a/tests/odm/operators/find/test_logical.py
+++ b/tests/odm/operators/find/test_logical.py
@@ -19,8 +19,8 @@ async def test_not(preset_documents):
     docs = await Sample.find(q).to_list()
     assert len(docs) == 7
 
+    q = Not(And(Sample.integer == 1, Sample.nested.integer > 3))
     with pytest.raises(AttributeError):
-        q = Not(And(Sample.integer == 1, Sample.nested.integer > 3))
         await Sample.find(q).to_list()
 
 

--- a/tests/odm/query/test_update.py
+++ b/tests/odm/query/test_update.py
@@ -1,4 +1,4 @@
-import asyncio
+import datetime as dt
 
 import pytest
 
@@ -142,31 +142,41 @@ async def test_update_many_with_session(preset_documents, session):
 
 
 async def test_update_many_upsert_with_insert(
-    preset_documents, sample_doc_not_saved
+    preset_documents, sample_doc_not_saved, time_machine
 ):
+    time_machine.move_to(dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc))
+
     await Sample.find_many(Sample.integer > 100000).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
-    await asyncio.sleep(2)
-    new_docs = await Sample.find_many(
+
+    # Advance time to ensure eventual consistency/cache expiration
+    time_machine.shift(dt.timedelta(seconds=11))
+
+    docs = await Sample.find_many(
         Sample.string == sample_doc_not_saved.string
     ).to_list()
-    assert len(new_docs) == 1
-    doc = new_docs[0]
+    assert len(docs) == 1
+    doc = docs[0]
     assert doc.integer == sample_doc_not_saved.integer
 
 
 async def test_update_many_upsert_without_insert(
-    preset_documents, sample_doc_not_saved
+    preset_documents, sample_doc_not_saved, time_machine
 ):
+    time_machine.move_to(dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc))
+
     await Sample.find_many(Sample.integer > 1).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
-    await asyncio.sleep(2)
-    new_docs = await Sample.find_many(
+
+    # Advance time to ensure eventual consistency/cache expiration
+    time_machine.shift(dt.timedelta(seconds=11))
+
+    docs = await Sample.find_many(
         Sample.string == sample_doc_not_saved.string
     ).to_list()
-    assert len(new_docs) == 0
+    assert len(docs) == 0
 
 
 async def test_update_one_upsert_with_insert(
@@ -175,11 +185,11 @@ async def test_update_one_upsert_with_insert(
     await Sample.find_one(Sample.integer > 100000).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
-    new_docs = await Sample.find_many(
+    docs = await Sample.find_many(
         Sample.string == sample_doc_not_saved.string
     ).to_list()
-    assert len(new_docs) == 1
-    doc = new_docs[0]
+    assert len(docs) == 1
+    doc = docs[0]
     assert doc.integer == sample_doc_not_saved.integer
 
 
@@ -189,10 +199,10 @@ async def test_update_one_upsert_without_insert(
     await Sample.find_one(Sample.integer > 1).upsert(
         Set({Sample.integer: 100}), on_insert=sample_doc_not_saved
     )
-    new_docs = await Sample.find_many(
+    docs = await Sample.find_many(
         Sample.string == sample_doc_not_saved.string
     ).to_list()
-    assert len(new_docs) == 0
+    assert len(docs) == 0
 
 
 async def test_update_one_upsert_without_insert_return_doc(
@@ -205,10 +215,10 @@ async def test_update_one_upsert_without_insert_return_doc(
     )
     assert isinstance(result, Sample)
 
-    new_docs = await Sample.find_many(
+    docs = await Sample.find_many(
         Sample.string == sample_doc_not_saved.string
     ).to_list()
-    assert len(new_docs) == 0
+    assert len(docs) == 0
 
 
 async def test_update_pymongo_kwargs(preset_documents):

--- a/tests/odm/test_cache.py
+++ b/tests/odm/test_cache.py
@@ -1,29 +1,36 @@
-import asyncio
+import datetime as dt
 
 from tests.odm.models import DocumentTestModel
 
 
-async def test_find_one(documents):
+async def test_find_one(documents, time_machine):
+    time_machine.move_to(dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc))
+
     await documents(5)
+
     doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
+
     await DocumentTestModel.find_one(DocumentTestModel.test_int == 1).set(
         {DocumentTestModel.test_str: "NEW_VALUE"}
     )
-    new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
-    assert doc == new_doc
 
-    new_doc = await DocumentTestModel.find_one(
-        DocumentTestModel.test_int == 1, ignore_cache=True
+    cached_doc = await DocumentTestModel.find_one(
+        DocumentTestModel.test_int == 1
     )
-    assert doc != new_doc
+    assert doc == cached_doc
 
-    await asyncio.sleep(10)
+    # Advance time to ensure cache expiration
+    time_machine.shift(dt.timedelta(seconds=11))
 
-    new_doc = await DocumentTestModel.find_one(DocumentTestModel.test_int == 1)
-    assert doc != new_doc
+    refreshed_doc = await DocumentTestModel.find_one(
+        DocumentTestModel.test_int == 1
+    )
+    assert doc != refreshed_doc
 
 
-async def test_find_many(documents):
+async def test_find_many(documents, time_machine):
+    time_machine.move_to(dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc))
+
     await documents(5)
     docs = await DocumentTestModel.find(
         DocumentTestModel.test_int > 1
@@ -43,7 +50,8 @@ async def test_find_many(documents):
     ).to_list()
     assert docs != new_docs
 
-    await asyncio.sleep(10)
+    # Advance time to ensure cache expiration
+    time_machine.shift(dt.timedelta(seconds=11))
 
     new_docs = await DocumentTestModel.find(
         DocumentTestModel.test_int > 1
@@ -51,7 +59,9 @@ async def test_find_many(documents):
     assert docs != new_docs
 
 
-async def test_aggregation(documents):
+async def test_aggregation(documents, time_machine):
+    time_machine.move_to(dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc))
+
     await documents(5)
     docs = await DocumentTestModel.aggregate(
         [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]
@@ -72,7 +82,8 @@ async def test_aggregation(documents):
     ).to_list()
     assert docs != new_docs
 
-    await asyncio.sleep(10)
+    # Advance time to ensure cache expiration
+    time_machine.shift(dt.timedelta(seconds=11))
 
     new_docs = await DocumentTestModel.aggregate(
         [{"$group": {"_id": "$test_str", "total": {"$sum": "$test_int"}}}]

--- a/tests/odm/test_relations.py
+++ b/tests/odm/test_relations.py
@@ -733,7 +733,7 @@ class TestOther:
         }
 
 
-@pytest.fixture()
+@pytest.fixture
 async def link_and_backlink_doc_pair():
     back_link_doc = DocumentWithBackLink()
     await back_link_doc.insert()
@@ -742,7 +742,7 @@ async def link_and_backlink_doc_pair():
     return link_doc, back_link_doc
 
 
-@pytest.fixture()
+@pytest.fixture
 async def list_link_and_list_backlink_doc_pair():
     back_link_doc = DocumentWithListBackLink()
     await back_link_doc.insert()

--- a/tests/odm/test_typing_utils.py
+++ b/tests/odm/test_typing_utils.py
@@ -25,8 +25,8 @@ class TestTyping:
         assert extract_id_class(Link[Lock]) == Lock
 
     @pytest.mark.parametrize(
-        "type,result",
-        (
+        "type, result",
+        [
             (str, None),
             (Indexed(str), (1, {})),
             (Indexed(str, "text", unique=True), ("text", {"unique": True})),
@@ -36,7 +36,7 @@ class TestTyping:
                 (1, {"unique": True}),
             ),
             (Annotated[str, "other metadata"], None),
-        ),
+        ],
     )
     def test_get_index_attributes(self, type, result):
         class Foo(BaseModel):


### PR DESCRIPTION
This PR refactors the test infrastructure to significantly improve the test execution speed.

## 🚀 Performance

Test runtime improved substantially:
### Locally (on my machine)
- **Before:** ~7 minutes (430s)
- **After:** ~1.5 minute (95s)
- **~4.5x faster**

## Key changes

- Switched core fixtures (`settings`, `cli`, `db`) to **session scope** to reuse MongoDB connections.
- Run `init_beanie()` **once per test session** instead of per test.
- Added an **automatic database cleanup fixture** to ensure test isolation and to reset the model cache because of the new "shared" approach.
- Added **`time-machine`** test dependency for deterministic cache-expiration testing instead of introducing real delays.
- Minor test cleanups and lint configuration adjustments.

## Result

- Faster test execution
- Reduced database/client initialization overhead
- Deterministic cache behavior in tests
- More consistent and maintainable test setup