### PR TITLE
add context7 docs

### DIFF
--- a/beanie/odm/actions.py
+++ b/beanie/odm/actions.py
@@ -20,6 +20,31 @@ R = TypeVar("R")
 
 
 class EventTypes(str, Enum):
+    """Enumeration of document lifecycle events that can trigger actions.
+
+    Use these values (or their module-level aliases) with
+    :func:`before_event` and :func:`after_event` decorators to attach
+    hooks to specific operations on a :class:`~beanie.Document`.
+
+    Aliases defined at module level for convenience:
+    ``Insert``, ``Replace``, ``Save``, ``SaveChanges``,
+    ``ValidateOnSave``, ``Delete``, ``Update``.
+
+    Example::
+
+        class Article(Document):
+            title: str
+            slug: str
+
+            @before_event(Insert)
+            def generate_slug(self):
+                self.slug = self.title.lower().replace(" ", "-")
+
+            @after_event(Delete)
+            async def notify_deleted(self):
+                await send_notification(f"{self.title} was deleted")
+    """
+
     INSERT = "INSERT"
     REPLACE = "REPLACE"
     SAVE = "SAVE"
@@ -39,6 +64,13 @@ Update = EventTypes.UPDATE
 
 
 class ActionDirections(str, Enum):  # TODO think about this name
+    """Whether an action runs before or after the triggering event.
+
+    Module-level aliases ``Before`` and ``After`` are provided for
+    convenience and are the values typically passed to
+    :func:`before_event` / :func:`after_event`.
+    """
+
     BEFORE = "BEFORE"
     AFTER = "AFTER"
 

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -135,6 +135,16 @@ def document_alias_generator(s: str) -> str:
 
 
 class MergeStrategy(str, Enum):
+    """Strategy used by :meth:`Document.sync` to resolve divergence between
+    the in-memory document and the current state in the database.
+
+    - ``remote`` *(default)* — overwrite the local copy with the database
+      version, discarding any unsaved local changes.
+    - ``local`` — re-apply local (unsaved) changes on top of the latest
+      database version.  Requires ``use_state_management = True`` in the
+      document's ``Settings``.
+    """
+
     local = "local"
     remote = "remote"
 
@@ -1055,6 +1065,12 @@ class Document(
     @property
     @saved_state_needed
     def is_changed(self) -> bool:
+        """``True`` if the document has unsaved changes relative to the last
+        saved state.
+
+        Requires ``use_state_management = True`` in the document's
+        ``Settings``; raises ``StateManagementIsTurnedOff`` otherwise.
+        """
         return self._saved_state != get_dict(
             self,
             to_db=True,
@@ -1066,6 +1082,13 @@ class Document(
     @saved_state_needed
     @previous_saved_state_needed
     def has_changed(self) -> bool:
+        """``True`` if the document's saved state differs from the *previous*
+        saved state (i.e. the document was modified between two consecutive
+        save operations).
+
+        Requires both ``use_state_management = True`` **and**
+        ``save_previous_state = True`` in the document's ``Settings``.
+        """
         if self._previous_saved_state is None:
             return False
         return self._previous_saved_state != self._saved_state
@@ -1111,6 +1134,15 @@ class Document(
 
     @saved_state_needed
     def get_changes(self) -> dict[str, Any]:
+        """Return a dict of field paths that have changed since the last save.
+
+        Keys are dot-notation field paths (e.g. ``"address.city"``), values
+        are the current (unsaved) values.  Returns an empty dict when nothing
+        has changed.
+
+        Requires ``use_state_management = True`` in the document's
+        ``Settings``.
+        """
         assert self._saved_state is not None
 
         return self._collect_updates(
@@ -1126,6 +1158,16 @@ class Document(
     @saved_state_needed
     @previous_saved_state_needed
     def get_previous_changes(self) -> dict[str, Any]:
+        """Return a dict of field paths that changed between the *previous*
+        saved state and the *current* saved state.
+
+        Useful for audit logging: call this inside an ``@after_event(Save)``
+        hook to see exactly what was updated.  Returns ``{}`` when no
+        previous state exists.
+
+        Requires both ``use_state_management = True`` and
+        ``save_previous_state = True`` in the document's ``Settings``.
+        """
         assert self._saved_state is not None
 
         if self._previous_saved_state is None:
@@ -1138,6 +1180,14 @@ class Document(
 
     @saved_state_needed
     def rollback(self) -> None:
+        """Discard unsaved changes by restoring the document to its last saved state.
+
+        All fields that differ from the saved state are reset in-place.
+        Has no effect if the document has not been changed.
+
+        Requires ``use_state_management = True`` in the document's
+        ``Settings``.
+        """
         assert self._saved_state is not None
 
         if self.is_changed:
@@ -1210,12 +1260,28 @@ class Document(
 
     @wrap_with_actions(event_type=EventTypes.VALIDATE_ON_SAVE)
     async def validate_self(self, *args: Any, **kwargs: Any):
+        """Re-validate all document fields using Pydantic's model parser.
+
+        Called automatically before write operations when
+        ``validate_on_save = True`` is set in the document's ``Settings``.
+        Also fires ``before_event(ValidateOnSave)`` /
+        ``after_event(ValidateOnSave)`` hooks.
+
+        You can call this manually to trigger validation without persisting::
+
+            await doc.validate_self()
+        """
         # TODO: it can be sync, but needs some actions controller improvements
         if self.get_settings().validate_on_save:
             new_model = parse_model(self.__class__, get_model_dump(self))
             merge_models(self, new_model)
 
     def to_ref(self):
+        """Return a :class:`~bson.DBRef` pointing to this document.
+
+        :raises DocumentWasNotSaved: if the document has not been inserted
+            yet (``id`` is ``None``).
+        """
         if self.id is None:
             raise DocumentWasNotSaved("Can not create dbref without id")
         return DBRef(self.get_pymongo_collection().name, self.id)
@@ -1263,6 +1329,19 @@ class Document(
             setattr(self, field, values)
 
     async def fetch_all_links(self):
+        """Resolve all :class:`~beanie.Link` and :class:`~beanie.BackLink`
+        fields on this document in a single concurrent call.
+
+        Equivalent to calling :meth:`fetch_link` for every relation field.
+        After awaiting, all link fields are replaced with the fetched
+        document instances (or lists of instances).
+
+        Example::
+
+            article = await Article.get(article_id)
+            await article.fetch_all_links()
+            print(article.author.name)  # Author is now resolved
+        """
         coros = []
         link_fields = self.get_link_fields()
         if link_fields is not None:
@@ -1286,12 +1365,39 @@ class Document(
         session: AsyncClientSession | None = None,
         **kwargs: Any,
     ) -> list:
+        """Return a list of distinct values for ``key`` across the collection.
+
+        :param key: The field name (or dot-notation path) to get distinct
+            values for.
+        :param filter: Optional MongoDB filter document to restrict the
+            documents considered.
+        :param session: Optional pymongo session for transactional use.
+        :param kwargs: Additional keyword arguments forwarded to the
+            underlying ``pymongo`` ``distinct`` call.
+        :return: List of distinct values.
+
+        Example::
+
+            categories = await Product.distinct("category.name")
+            active_tags = await Product.distinct(
+                "tags", filter={"active": True}
+            )
+        """
         return await cls.get_pymongo_collection().distinct(
             key=key, filter=filter, session=session, **kwargs
         )
 
     @classmethod
     def link_from_id(cls, id: Any):
+        """Create an unresolved :class:`~beanie.Link` for this document type
+        from a raw id value, without querying the database.
+
+        Useful when you already know the id and want to store a reference
+        without fetching the full document::
+
+            article.author = Author.link_from_id(known_author_id)
+            await article.save()
+        """
         ref = DBRef(id=id, collection=cls.get_collection_name())
         return Link(ref, document_class=cls)
 

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -193,6 +193,35 @@ class FieldResolution:
 
 
 class ExpressionField(str):
+    """A string subclass used to build type-safe MongoDB query expressions.
+
+    Instances are created automatically when you access a field on a
+    :class:`~beanie.Document` class (e.g. ``Product.price``).  Attribute
+    access chains are translated into dot-notation paths (e.g.
+    ``Product.category.name`` → ``"category.name"``), and Pydantic field
+    aliases are resolved automatically.
+
+    Comparison operators (``==``, ``>``, ``>=``, ``<``, ``<=``, ``!=``)
+    return the appropriate :mod:`beanie.odm.operators.find` objects so
+    they can be passed directly to ``find()`` / ``find_one()``.
+
+    Unary ``+`` / ``-`` return ``(field, SortDirection)`` tuples accepted
+    by ``sort()``.
+
+    Example::
+
+        # Field access
+        Product.category.name        # ExpressionField("category.name")
+
+        # Query operators
+        Product.find(Product.price > 10)
+        Product.find(Product.name == "Chocolate")
+
+        # Sorting
+        Product.find().sort(+Product.price)
+        Product.find().sort(-Product.price)
+    """
+
     def __new__(cls, path, field_resolution=None):
         instance = super().__new__(cls, path)
         instance._field_resolution = (
@@ -309,29 +338,37 @@ class ExpressionField(str):
         return hash(str(self))
 
     def __eq__(self, other):
+        """Return an equality filter expression, or delegate to str.__eq__ when comparing two ExpressionFields."""
         if isinstance(other, ExpressionField):
             return super().__eq__(other)
         return Eq(field=self, other=other)
 
     def __gt__(self, other):
+        """Return a greater-than filter expression."""
         return GT(field=self, other=other)
 
     def __ge__(self, other):
+        """Return a greater-than-or-equal filter expression."""
         return GTE(field=self, other=other)
 
     def __lt__(self, other):
+        """Return a less-than filter expression."""
         return LT(field=self, other=other)
 
     def __le__(self, other):
+        """Return a less-than-or-equal filter expression."""
         return LTE(field=self, other=other)
 
     def __ne__(self, other):
+        """Return a not-equal filter expression."""
         return NE(field=self, other=other)
 
     def __pos__(self):
+        """Return an ascending sort tuple ``(field, SortDirection.ASCENDING)``."""
         return self, SortDirection.ASCENDING
 
     def __neg__(self):
+        """Return a descending sort tuple ``(field, SortDirection.DESCENDING)``."""
         return self, SortDirection.DESCENDING
 
     def __copy__(self):
@@ -342,16 +379,53 @@ class ExpressionField(str):
 
 
 class DeleteRules(str, Enum):
+    """Controls what happens to linked documents when the parent is deleted.
+
+    Pass as the ``link_rule`` argument to :meth:`~beanie.Document.delete`.
+
+    - ``DO_NOTHING`` *(default)* — linked documents are left untouched.
+    - ``DELETE_LINKS`` — each linked document is also deleted recursively.
+
+    Example::
+
+        await article.delete(link_rule=DeleteRules.DELETE_LINKS)
+    """
+
     DO_NOTHING = "DO_NOTHING"
     DELETE_LINKS = "DELETE_LINKS"
 
 
 class WriteRules(str, Enum):
+    """Controls whether linked documents are persisted when the parent is saved.
+
+    Pass as the ``link_rule`` argument to
+    :meth:`~beanie.Document.insert`, :meth:`~beanie.Document.save`,
+    :meth:`~beanie.Document.replace`, etc.
+
+    - ``DO_NOTHING`` *(default)* — linked documents are **not** written;
+      only the DBRef is stored on the parent.
+    - ``WRITE`` — each linked document is upserted to the database before
+      the parent is written.
+
+    Example::
+
+        await article.insert(link_rule=WriteRules.WRITE)
+    """
+
     DO_NOTHING = "DO_NOTHING"
     WRITE = "WRITE"
 
 
 class LinkTypes(str, Enum):
+    """Internal classification of relation field variants.
+
+    Used by Beanie's initialisation logic to determine how a
+    :class:`Link` or :class:`BackLink` field should be fetched and
+    serialised.  You will not normally need to reference these values
+    directly — they are set automatically when a document class is
+    initialised.
+    """
+
     DIRECT = "DIRECT"
     OPTIONAL_DIRECT = "OPTIONAL_DIRECT"
     LIST = "LIST"
@@ -364,6 +438,13 @@ class LinkTypes(str, Enum):
 
 
 class LinkInfo(BaseModel):
+    """Runtime metadata describing a relation field on a document class.
+
+    Populated automatically by Beanie's initialisation step and stored
+    on ``Document._link_fields``.  Used internally to resolve fetch
+    queries and to apply :class:`WriteRules` / :class:`DeleteRules`.
+    """
+
     field_name: str
     lookup_field_name: str
     document_class: type[BaseModel]  # Document class
@@ -376,11 +457,43 @@ T = TypeVar("T")
 
 
 class Link(Generic[T]):
+    """A lazy reference to another :class:`~beanie.Document`.
+
+    Stored in MongoDB as a ``DBRef`` (``{"$ref": ..., "$id": ...}``).
+    The referenced document is **not** loaded from the database until
+    :meth:`fetch` (or a higher-level helper such as
+    :meth:`~beanie.Document.fetch_link`) is awaited.
+
+    Declare a relation field using ``Link[T]`` as the type annotation::
+
+        class Article(Document):
+            author: Link[Author]
+            # Optional relation
+            editor: Link[Author] | None = None
+            # List of relations
+            tags: list[Link[Tag]] = []
+
+    Insert behaviour is controlled by :class:`WriteRules` and delete
+    behaviour by :class:`DeleteRules`.
+
+    To resolve the reference, either:
+
+    - ``await article.fetch_link(Article.author)`` — fetches one field
+    - ``await article.fetch_all_links()`` — fetches all link fields
+    - Pass ``fetch_links=True`` to ``find()`` / ``find_one()`` / ``get()``
+    """
+
     def __init__(self, ref: DBRef, document_class: type[T]):
         self.ref = ref
         self.document_class = document_class
 
     async def fetch(self, fetch_links: bool = False) -> "T | Link[T]":
+        """Fetch the referenced document from the database.
+
+        :param fetch_links: If ``True``, also resolve link fields on the
+            fetched document.
+        :return: The resolved document, or ``self`` if not found.
+        """
         result = await self.document_class.get(  # type: ignore
             self.ref.id, with_children=True, fetch_links=fetch_links
         )
@@ -388,6 +501,7 @@ class Link(Generic[T]):
 
     @classmethod
     async def fetch_one(cls, link: "Link[T]"):
+        """Fetch a single link. Convenience wrapper around :meth:`fetch`."""
         return await link.fetch()
 
     @classmethod
@@ -432,6 +546,8 @@ class Link(Generic[T]):
     def repack_links(
         links: list["Link[T] | DocType"],
     ) -> OrderedDict[Any, Any]:
+        """Convert a mixed list of Link objects and resolved documents into an
+        OrderedDict keyed by document id, preserving insertion order."""
         result = OrderedDict()
         for link in links:
             if isinstance(link, Link):
@@ -442,6 +558,11 @@ class Link(Generic[T]):
 
     @classmethod
     async def fetch_many(cls, links: list["Link[T]"]) -> list["T | Link[T]"]:
+        """Fetch multiple links concurrently using ``asyncio.gather``.
+
+        Unlike :meth:`fetch_list`, this method issues one database
+        round-trip per link rather than a single batched query.
+        """
         coros = []
         for link in links:
             coros.append(link.fetch())
@@ -526,14 +647,44 @@ class Link(Generic[T]):
         )
 
     def to_ref(self):
+        """Return the underlying :class:`~bson.DBRef` for this link."""
         return self.ref
 
     def to_dict(self):
+        """Serialise the link as ``{"id": str, "collection": str}``."""
         return {"id": str(self.ref.id), "collection": self.ref.collection}
 
 
 class BackLink(Generic[T]):
-    """Back reference to a document"""
+    """A virtual back-reference from a child document to its parent.
+
+    ``BackLink`` fields are **not** stored in MongoDB — they are resolved
+    at query time by searching the referenced collection for documents
+    whose :class:`Link` field points back to the current document.
+
+    Declare a back-reference using ``BackLink[T]`` as the type
+    annotation and set the ``original_field`` extra to the name of the
+    forward-``Link`` field on the related model::
+
+        from beanie import Document, Link, BackLink
+        from pydantic import Field
+
+        class Author(Document):
+            name: str
+            # Each Author can see all Articles that reference it
+            articles: list[BackLink["Article"]] = Field(
+                original_field="author", default=[]
+            )
+
+        class Article(Document):
+            title: str
+            author: Link[Author]
+
+    Back-references are resolved lazily.  Call
+    :meth:`~beanie.Document.fetch_link` or
+    :meth:`~beanie.Document.fetch_all_links` to populate them, or pass
+    ``fetch_links=True`` to ``find()`` / ``find_one()``.
+    """
 
     def __init__(self, document_class: type[T]):
         self.document_class = document_class
@@ -582,6 +733,14 @@ class BackLink(Generic[T]):
 
 
 class IndexModelField:
+    """Wrapper around :class:`~pymongo.IndexModel` used internally by Beanie.
+
+    Provides equality comparison (by field key + options) and utility
+    helpers for diffing and merging index lists during collection
+    initialisation.  Not part of the public API — use
+    :func:`Indexed` or ``Document.Settings.indexes`` to declare indexes.
+    """
+
     def __init__(self, index: IndexModel):
         self.index = index
         self.name = index.document["name"]

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://context7.com/schema.json",
+  "projectTitle": "Beanie ODM",
+  "description": "Async Python ODM for MongoDB built on Motor and Pydantic v2. Provides document modeling, CRUD operations, aggregation pipelines, relations (Link/BackLink), event hooks, migrations, and FastAPI integration.",
+  "branch": "main",
+  "folders": ["docs", "beanie"],
+  "excludeFolders": ["tests", "assets", "scripts"],
+  "excludeFiles": ["CHANGELOG.md", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md"],
+  "rules": [
+    "Always call init_beanie() with the Motor AsyncIOMotorClient and list of document models before using the ODM",
+    "Use async/await for all database operations — all query methods are coroutines",
+    "Use find(), find_one(), find_all() for queries; chain .sort(), .skip(), .limit() before awaiting",
+    "Use .update(), .set(), .inc() for partial updates; use .save() to persist full document changes",
+    "Use Link[] and BackLink[] field types for document relations; call fetch_link() or fetch_all_links() to resolve them",
+    "Use @before_event and @after_event decorators with Insert/Update/Delete/Save events for hooks",
+    "Use BulkWriter context manager for batch operations to reduce round trips",
+    "Indexed() field wrapper creates MongoDB indexes; compound indexes use compound_index in Settings",
+    "Document.Settings inner class configures collection name, indexes, timeseries, and other options",
+    "Use WriteRules.CASCADE or WriteRules.DO_NOTHING when saving documents with relations"
+  ],
+  "previousVersions": [
+    {"tag": "v2.0.0"},
+    {"tag": "v1.26.0"},
+    {"tag": "v1.25.0"}
+  ]
+}

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1,0 +1,460 @@
+# Beanie Cheatsheet
+
+Quick reference for the most common Beanie patterns.
+
+---
+
+## Setup
+
+```python
+import motor.motor_asyncio
+from beanie import init_beanie, Document
+
+client = motor.motor_asyncio.AsyncIOMotorClient("mongodb://localhost:27017")
+
+await init_beanie(
+    database=client.my_database,
+    document_models=[Product, Author, Article],  # all Document subclasses
+)
+```
+
+---
+
+## Define a Document
+
+```python
+from beanie import Document, Indexed
+from pydantic import Field
+from bson import ObjectId
+
+
+class Product(Document):
+    name: Indexed(str, unique=True)   # creates a unique index
+    price: float
+    category: str = "general"
+    tags: list[str] = []
+
+    class Settings:
+        name = "products"             # MongoDB collection name
+        use_state_management = True   # enables is_changed, get_changes, rollback
+        validate_on_save = True       # validates before every write
+```
+
+---
+
+## Insert
+
+```python
+# Single insert
+product = Product(name="Widget", price=9.99)
+await product.insert()
+
+# Shorthand (alias for insert)
+await product.create()
+
+# Insert many
+await Product.insert_many([
+    Product(name="A", price=1.0),
+    Product(name="B", price=2.0),
+])
+```
+
+---
+
+## Find
+
+```python
+# By id
+product = await Product.get(product_id)            # returns None if not found
+
+# Find one
+product = await Product.find_one(Product.name == "Widget")
+
+# Find many → list
+products = await Product.find(Product.price < 50).to_list()
+
+# Chaining
+products = await (
+    Product.find(Product.category == "tech")
+    .sort(-Product.price)    # descending
+    .skip(10)
+    .limit(5)
+    .to_list()
+)
+
+# All documents
+all_products = await Product.find_all().to_list()
+# or
+all_products = await Product.find().to_list()
+
+# Count
+n = await Product.find(Product.price > 10).count()
+
+# Exists check
+exists = await Product.find(Product.name == "Widget").exists()
+
+# Distinct values
+categories = await Product.distinct("category")
+```
+
+---
+
+## Update
+
+```python
+# Update via instance
+product.price = 12.99
+await product.save()              # full replace
+await product.save_changes()      # only changed fields ($set)
+
+# Update operators (no fetch required)
+await product.set({Product.price: 12.99})
+await product.inc({Product.price: 1.0})
+await product.current_date({Product.updated_at: True})
+
+# Update many
+await Product.find(Product.category == "old").update(
+    {"$set": {"category": "archive"}}
+)
+
+# Upsert
+await Product.find_one(Product.name == "Widget").upsert(
+    {"$set": {"price": 9.99}},
+    on_insert=Product(name="Widget", price=9.99),
+)
+```
+
+---
+
+## Delete
+
+```python
+# Single
+await product.delete()
+
+# Via query
+await Product.find_one(Product.name == "Widget").delete()
+
+# Many
+await Product.find(Product.price < 0).delete()
+
+# All
+await Product.delete_all()
+```
+
+---
+
+## Projections
+
+```python
+from pydantic import BaseModel
+
+
+class ProductSummary(BaseModel):
+    name: str
+    price: float
+
+
+summaries = await Product.find().project(ProductSummary).to_list()
+```
+
+---
+
+## Relations
+
+```python
+from beanie import Link, BackLink, WriteRules, DeleteRules
+from pydantic import Field
+
+
+class Author(Document):
+    name: str
+    articles: list[BackLink["Article"]] = Field(
+        original_field="author", default=[]
+    )
+
+
+class Article(Document):
+    title: str
+    author: Link[Author]
+    tags: list[Link[Tag]] = []
+```
+
+```python
+# Insert with linked document creation
+article = Article(title="Hello", author=author_instance)
+await article.insert(link_rule=WriteRules.WRITE)  # also inserts author
+
+# Fetch one link field
+await article.fetch_link(Article.author)
+print(article.author.name)
+
+# Fetch all link fields at once
+await article.fetch_all_links()
+
+# Query with auto-fetch
+article = await Article.find_one(
+    Article.title == "Hello",
+    fetch_links=True,
+)
+
+# Delete and cascade
+await article.delete(link_rule=DeleteRules.DELETE_LINKS)
+
+# Build a link without fetching
+article.author = Author.link_from_id(known_author_id)
+await article.save()
+```
+
+---
+
+## Event Hooks (Actions)
+
+```python
+from beanie import before_event, after_event, Insert, Save, Delete
+
+
+class Article(Document):
+    title: str
+    slug: str
+
+    @before_event(Insert)
+    def generate_slug(self):
+        self.slug = self.title.lower().replace(" ", "-")
+
+    @before_event([Save, Insert])
+    async def validate_title(self):
+        if len(self.title) < 3:
+            raise ValueError("Title too short")
+
+    @after_event(Delete)
+    async def cleanup(self):
+        await notify_deleted(self.id)
+```
+
+---
+
+## Bulk Writes
+
+```python
+async with Product.bulk_writer() as bulk:
+    await Product(name="A", price=1.0).insert(bulk_writer=bulk)
+    await Product(name="B", price=2.0).insert(bulk_writer=bulk)
+    await Product.find_one(Product.name == "Old").delete(bulk_writer=bulk)
+# All operations sent in a single round-trip on context exit
+```
+
+---
+
+## State Management
+
+```python
+class Product(Document):
+    price: float
+
+    class Settings:
+        use_state_management = True
+        save_previous_state = True   # required for has_changed / get_previous_changes
+
+
+product = await Product.find_one(...)
+product.price = 99.0
+
+if product.is_changed:
+    print(product.get_changes())         # {"price": 99.0}
+
+await product.save()
+print(product.get_previous_changes())    # {"price": <old value>}
+
+# Discard unsaved changes
+product.rollback()
+```
+
+---
+
+## Aggregations
+
+```python
+# Built-in
+avg = await Product.avg(Product.price)
+total = await Product.sum(Product.price)
+minimum = await Product.min(Product.price)
+maximum = await Product.max(Product.price)
+
+# Scoped
+avg_tech = await Product.find(Product.category == "tech").avg(Product.price)
+
+# Custom pipeline
+from pydantic import BaseModel, Field
+
+
+class CategoryStats(BaseModel):
+    id: str = Field(alias="_id")
+    avg_price: float
+    count: int
+
+
+stats = await Product.aggregate(
+    [
+        {"$group": {"_id": "$category", "avg_price": {"$avg": "$price"}, "count": {"$sum": 1}}},
+        {"$sort": {"avg_price": -1}},
+    ],
+    projection_model=CategoryStats,
+).to_list()
+```
+
+---
+
+## Indexes
+
+```python
+from beanie import Document, Indexed
+from pymongo import IndexModel, ASCENDING, DESCENDING, TEXT
+from pydantic import Field
+from typing import Annotated
+
+
+class Article(Document):
+    # Single-field index via Indexed()
+    title: Indexed(str)
+    # Unique index
+    slug: Indexed(str, unique=True)
+    # Annotated syntax
+    author_id: Annotated[str, Indexed()]
+
+    class Settings:
+        name = "articles"
+        indexes = [
+            # Compound index
+            IndexModel([("title", ASCENDING), ("author_id", ASCENDING)]),
+            # Full-text index
+            IndexModel([("title", TEXT)]),
+        ]
+```
+
+---
+
+## Inheritance
+
+```python
+from beanie import Document
+
+
+class Shape(Document):
+    color: str
+
+    class Settings:
+        name = "shapes"
+        is_root = True            # store all subtypes in one collection
+
+
+class Circle(Shape):
+    radius: float
+
+
+class Rectangle(Shape):
+    width: float
+    height: float
+
+
+# Insert subtypes
+await Circle(color="red", radius=5.0).insert()
+await Rectangle(color="blue", width=3.0, height=4.0).insert()
+
+# Query all shapes (polymorphic)
+all_shapes = await Shape.find_all().to_list()
+
+# Query only circles
+circles = await Circle.find_all().to_list()
+```
+
+---
+
+## Soft Delete
+
+```python
+from beanie import DocumentWithSoftDelete
+
+
+class Post(DocumentWithSoftDelete):
+    title: str
+
+
+post = await Post.find_one(Post.title == "Draft")
+await post.delete()             # marks deleted_at, stays in DB
+
+# Only non-deleted posts
+active = await Post.find_all().to_list()
+
+# Include soft-deleted
+all_posts = await Post.find_many_in_all().to_list()
+
+# Permanent removal
+await post.hard_delete()
+```
+
+---
+
+## Revision (Optimistic Concurrency)
+
+```python
+from beanie.exceptions import RevisionIdWasChanged
+
+
+class Account(Document):
+    balance: float
+
+    class Settings:
+        use_revision = True
+
+
+account = await Account.get(account_id)
+account.balance += 100.0
+
+try:
+    await account.save()
+except RevisionIdWasChanged:
+    # Another process modified the document — re-fetch and retry
+    account = await Account.get(account_id)
+    ...
+```
+
+---
+
+## Sessions & Transactions
+
+```python
+async with await client.start_session() as session:
+    async with session.start_transaction():
+        await product.insert(session=session)
+        await stock.update({"$inc": {"qty": -1}}, session=session)
+```
+
+---
+
+## Migrations
+
+```bash
+# Create a new migration file
+beanie new-migration -n add_slug_field -p ./migrations
+
+# Run all pending migrations
+beanie migrate -uri mongodb://localhost/mydb -db mydb -p ./migrations
+```
+
+```python
+# migrations/20240101_add_slug_field.py
+from beanie.migrations.models import RunningDirections
+
+async def migrate(db, session=None):
+    await db["articles"].update_many(
+        {"slug": {"$exists": False}},
+        [{"$set": {"slug": {"$toLower": "$title"}}}],
+        session=session,
+    )
+
+async def backward(db, session=None):
+    await db["articles"].update_many(
+        {}, {"$unset": {"slug": ""}}, session=session
+    )
+```

--- a/docs/tutorial/aggregate.md
+++ b/docs/tutorial/aggregate.md
@@ -1,33 +1,157 @@
 # Aggregations
 
-You can perform aggregation queries through beanie as well. For example, to calculate the average:
+## Built-in Aggregation Methods
+
+Beanie exposes the most common aggregation operations as chainable query
+methods.  They can be applied to the whole collection or scoped to a filtered
+subset of documents.
 
 ```python
-# With a search:
-avg_price = await Product.find(
-    Product.category.name == "Chocolate"
-).avg(Product.price)
+from beanie import Document
+from pydantic import Field
 
-# Over the whole collection:
-avg_price = await Product.avg(Product.price)
+
+class Product(Document):
+    name: str
+    price: float
+    category: str
+    in_stock: bool = True
+
+    class Settings:
+        name = "products"
 ```
 
-A full list of available methods can be found [here](../api-documentation/interfaces.md/#aggregatemethods).
-
-You can also use the native PyMongo syntax by calling the `aggregate` method. 
-However, as Beanie will not know what output to expect, you will have to supply a projection model yourself. 
-If you do not supply a projection model, then a dictionary will be returned.
+### Average
 
 ```python
-class OutputItem(BaseModel):
-    id: str = Field(None, alias="_id")
-    total: float
+# Average price across the whole collection
+avg_price = await Product.avg(Product.price)
+
+# Average price within a category
+avg_chocolate_price = await Product.find(
+    Product.category == "Chocolate"
+).avg(Product.price)
+```
+
+### Sum
+
+```python
+total_value = await Product.sum(Product.price)
+
+total_chocolate_value = await Product.find(
+    Product.category == "Chocolate"
+).sum(Product.price)
+```
+
+### Min and Max
+
+```python
+cheapest = await Product.min(Product.price)
+most_expensive = await Product.max(Product.price)
+```
+
+### Count
+
+```python
+total_products = await Product.count()
+chocolate_count = await Product.find(Product.category == "Chocolate").count()
+```
+
+A full list of available methods is in the
+[API documentation](../api-documentation/interfaces.md/#aggregatemethods).
+
+---
+
+## Native Aggregation Pipelines
+
+For more complex queries, use `aggregate()` with a standard MongoDB pipeline.
+Because Beanie cannot infer the output shape, you must provide a
+`projection_model` (a Pydantic `BaseModel`) or accept plain `dict` results.
+
+### Group by field and compute average
+
+```python
+from pydantic import BaseModel
 
 
-result = await Product.find(
-    Product.category.name == "Chocolate").aggregate(
-    [{"$group": {"_id": "$category.name", "total": {"$avg": "$price"}}}],
-    projection_model=OutputItem
+class CategoryStats(BaseModel):
+    id: str = Field(alias="_id")
+    average_price: float
+    total_products: int
+
+
+stats = await Product.aggregate(
+    [
+        {
+            "$group": {
+                "_id": "$category",
+                "average_price": {"$avg": "$price"},
+                "total_products": {"$sum": 1},
+            }
+        },
+        {"$sort": {"average_price": -1}},
+    ],
+    projection_model=CategoryStats,
 ).to_list()
 
+for s in stats:
+    print(f"{s.id}: avg={s.average_price:.2f}, count={s.total_products}")
 ```
+
+### Filter then aggregate
+
+```python
+class PriceBucket(BaseModel):
+    id: str = Field(alias="_id")
+    count: int
+
+
+buckets = await Product.find(Product.in_stock == True).aggregate(
+    [
+        {
+            "$bucket": {
+                "groupBy": "$price",
+                "boundaries": [0, 10, 50, 100, 500],
+                "default": "500+",
+                "output": {"count": {"$sum": 1}},
+            }
+        }
+    ],
+    projection_model=PriceBucket,
+).to_list()
+```
+
+### Without a projection model (returns dicts)
+
+```python
+raw_results = await Product.aggregate(
+    [{"$group": {"_id": "$category", "total": {"$sum": "$price"}}}]
+).to_list()
+
+for row in raw_results:
+    print(row["_id"], row["total"])
+```
+
+---
+
+## Aggregation vs. Find
+
+| Scenario | Recommended approach |
+|---|---|
+| Simple filtering and sorting | `find()` + `sort()` / `skip()` / `limit()` |
+| Single-metric statistics (avg, sum, min, max) | Built-in aggregation methods |
+| Grouping, bucketing, reshaping documents | `aggregate()` with a pipeline |
+| Joining collections (`$lookup`) | `aggregate()` with a pipeline |
+| Complex multi-stage transformations | `aggregate()` with a pipeline |
+
+---
+
+## Tips
+
+- **Use `$match` early** in the pipeline to reduce the working set before
+  expensive stages like `$group` or `$lookup`.
+- **Leverage indexes** — a `$match` on an indexed field will use that index
+  even inside an aggregation pipeline.
+- **Reuse find filters** — `Product.find(Product.in_stock == True).aggregate(...)`
+  prepends a `$match` stage automatically, so you do not need to repeat the
+  filter inside the pipeline.

--- a/docs/tutorial/delete.md
+++ b/docs/tutorial/delete.md
@@ -1,31 +1,128 @@
-# Delete documents
+# Delete Documents
 
-Beanie supports single and batch deletions:
+## Single Document
 
-## Single
+Delete one document fetched by a query or by id:
 
 ```python
-
+# Via a query
 await Product.find_one(Product.name == "Milka").delete()
 
-# Or
+# Via a fetched instance
 bar = await Product.find_one(Product.name == "Milka")
-await bar.delete()
+if bar is not None:
+    await bar.delete()
+
+# Via id
+product = await Product.get(product_id)
+if product is not None:
+    await product.delete()
 ```
 
-## Many
+## Many Documents
+
+Delete all documents matching a filter:
 
 ```python
-
 await Product.find(Product.category.name == "Chocolate").delete()
 ```
 
-## All
+## All Documents
+
+Delete every document in the collection:
 
 ```python
-
 await Product.delete_all()
-# Or
-await Product.all().delete()
+# Equivalent to:
+await Product.find().delete()
+```
 
+## Delete with Relations (DeleteRules)
+
+When a document has `Link` fields pointing to other documents, you can control
+what happens to those linked documents on deletion using `DeleteRules`.
+
+```python
+from beanie import Document, Link, DeleteRules
+
+
+class Author(Document):
+    name: str
+
+
+class Article(Document):
+    title: str
+    author: Link[Author]
+```
+
+**`DO_NOTHING` (default)** — the linked `Author` is left untouched.  Only
+the `Article` is removed:
+
+```python
+await article.delete(link_rule=DeleteRules.DO_NOTHING)
+```
+
+**`DELETE_LINKS`** — each linked document is also deleted recursively:
+
+```python
+await article.delete(link_rule=DeleteRules.DELETE_LINKS)
+# The referenced Author is deleted too
+```
+
+> **Caution:** `DELETE_LINKS` performs individual delete calls for each link.
+> For bulk operations consider handling relation cleanup manually.
+
+## Bulk Deletion
+
+Use `BulkWriter` when deleting many documents in a batch to reduce database
+round-trips:
+
+```python
+async with Product.bulk_writer() as bulk:
+    for product_id in ids_to_delete:
+        product = await Product.get(product_id)
+        if product:
+            await product.delete(bulk_writer=bulk)
+# All deletes are sent to MongoDB in a single bulk write
+```
+
+## Soft Delete
+
+If you want to keep documents in the database but mark them as deleted, inherit
+from `DocumentWithSoftDelete` instead of `Document`.  See the
+[Soft Delete tutorial](soft_delete.md) for full details.
+
+```python
+from beanie import DocumentWithSoftDelete
+
+
+class Article(DocumentWithSoftDelete):
+    title: str
+
+
+article = await Article.find_one(Article.title == "Hello")
+await article.delete()          # sets deleted_at timestamp, does NOT remove from DB
+await article.hard_delete()     # permanently removes from DB
+```
+
+## Session Support
+
+All delete operations accept an optional `session` parameter for use inside
+MongoDB transactions:
+
+```python
+async with await client.start_session() as session:
+    async with session.start_transaction():
+        await article.delete(session=session)
+        await author.delete(session=session)
+```
+
+## Return Value
+
+Instance `delete()` returns a `DeleteResult` from pymongo.  Class-level
+`find(...).delete()` also returns a `DeleteResult`:
+
+```python
+result = await Product.find(Product.price < 0).delete()
+print(result.deleted_count)
 ```

--- a/docs/tutorial/lazy_parse.md
+++ b/docs/tutorial/lazy_parse.md
@@ -1,12 +1,112 @@
-## Using Lazy Parsing in Queries
-Lazy parsing allows you to skip the parsing and validation process for documents and instead call it on demand for each field separately. This can be useful for optimizing performance in certain scenarios.
+# Lazy Parsing
 
-To use lazy parsing in your queries, you can pass the `lazy_parse=True` parameter to your find method.
+## What is Lazy Parsing?
 
-Here's an example of how to use lazy parsing in a find query:
+By default, when Beanie fetches documents from MongoDB, Pydantic validates and
+parses every field immediately — coercing types, running validators, and
+building nested models.  This is the safest option and is recommended for most
+use cases.
+
+**Lazy parsing** defers that work: the raw BSON data is stored as-is and
+each field is only validated when it is first accessed.  This can speed up
+queries that retrieve large documents but only read a small subset of their
+fields.
+
+## When to Use Lazy Parsing
+
+Consider lazy parsing when:
+
+- You are retrieving many documents but only reading one or two fields from
+  each.
+- The documents contain large embedded sub-documents or arrays that you do not
+  need for a particular operation.
+- Profiling has shown that Pydantic validation is a measurable bottleneck for
+  your specific query.
+
+Do **not** use lazy parsing when:
+
+- You need all fields to be validated upfront (e.g. for data integrity checks).
+- You are passing documents across async boundaries where the access order is
+  unpredictable.
+- Your document models use validators that have side effects.
+
+## Basic Usage
+
+Pass `lazy_parse=True` to any `find` / `find_many` query:
 
 ```python
-await Sample.find(Sample.number == 10, lazy_parse=True).to_list()
+from beanie import Document, init_beanie
+from pydantic import Field
+import motor.motor_asyncio
+
+
+class Product(Document):
+    name: str
+    price: float
+    description: str  # large field we don't need here
+    tags: list[str] = []
+
+    class Settings:
+        name = "products"
+
+
+# Only `name` will be validated on access; other fields stay raw until touched
+products = await Product.find(
+    Product.price < 50.0,
+    lazy_parse=True,
+).to_list()
+
+for p in products:
+    print(p.name)   # validated here
+    # p.description is not validated until this line is reached
 ```
 
-By setting lazy_parse=True, the parsing and validation process will be skipped and be called on demand when the respective fields will be used. This can potentially improve the performance of your query by reducing the amount of processing required upfront. However, keep in mind that using lazy parsing may also introduce some additional overhead when accessing the fields later on.
+## Lazy Parsing with Projections
+
+Combining lazy parsing with a projection is the most effective pattern —
+MongoDB only returns the fields you need, and Pydantic skips validation for
+anything not present:
+
+```python
+from pydantic import BaseModel
+
+
+class ProductSummary(BaseModel):
+    name: str
+    price: float
+
+
+summaries = await Product.find(
+    Product.price < 50.0,
+    lazy_parse=True,
+).project(ProductSummary).to_list()
+```
+
+## Field Access and Validation
+
+When you access a field on a lazily parsed document, the value is validated
+at that moment.  If the raw value does not pass validation, a `ValidationError`
+is raised at access time rather than at query time:
+
+```python
+# Suppose a document in the DB has `price: "not-a-number"` (corrupt data)
+products = await Product.find(lazy_parse=True).to_list()
+
+for p in products:
+    try:
+        print(p.price)       # ValidationError raised HERE, not during find()
+    except Exception as e:
+        print(f"Validation failed for {p.id}: {e}")
+```
+
+This means lazy parsing shifts error discovery from query time to field access
+time.  Keep this in mind when writing error-handling code.
+
+## Caveats and Limitations
+
+| Concern | Detail |
+|---|---|
+| **Error timing** | Validation errors surface on field access, not on query execution |
+| **Not thread/task safe by default** | If multiple coroutines access the same lazy document concurrently, validate once first |
+| **No guarantee of full validation** | Code paths that never touch a field will never validate it |
+| **Compatibility with `fetch_links`** | Link fields are still fetched eagerly; `lazy_parse` only affects non-link field validation |

--- a/docs/tutorial/on_save_validation.md
+++ b/docs/tutorial/on_save_validation.md
@@ -1,28 +1,124 @@
-# On save validation
+# On-Save Validation
 
-Pydantic has a very useful config to validate values on assignment - `validate_assignment = True`. 
-But, unfortunately, this is an expensive operation and doesn't fit some use cases.
-You can validate all the values before saving the document (`insert`, `replace`, `save`, `save_changes`) 
-with beanie config `validate_on_save` instead.
+## Overview
 
-This feature must be turned on in the `Settings` inner class explicitly:
+Pydantic supports `validate_assignment = True` in its model config, which
+validates every field assignment immediately.  This is convenient but adds
+overhead on every attribute write, which can be expensive in hot paths.
+
+Beanie provides an alternative: **validate on save**.  Validation runs once,
+just before the document is persisted to MongoDB (`insert`, `replace`, `save`,
+`save_changes`), rather than on every field assignment.
+
+## Enabling Validate-on-Save
+
+Set `validate_on_save = True` inside the document's `Settings` class:
 
 ```python
-class Sample(Document):
-    num: int
+from beanie import Document
+
+
+class Product(Document):
     name: str
+    price: float
+    stock: int = 0
 
     class Settings:
+        name = "products"
         validate_on_save = True
 ```
 
-If any field has a wrong value, 
-it will raise an error on write operations (`insert`, `replace`, `save`, `save_changes`).
+## How It Works
+
+When any write operation is called, Beanie re-parses the document through
+Pydantic before sending it to MongoDB.  If any field has an invalid value at
+that point, a `ValidationError` is raised and the write is aborted.
 
 ```python
-sample = Sample.find_one(Sample.name == "Test")
-sample.num = "wrong value type"
+product = await Product.find_one(Product.name == "Widget")
+product.price = "not-a-number"   # no error yet
 
-# Next call will raise an error
-await sample.replace()
+# ValidationError raised here — nothing is written to the database
+await product.save()
 ```
+
+## Catching Validation Errors
+
+```python
+from pydantic import ValidationError
+
+
+product = await Product.find_one(Product.name == "Widget")
+product.stock = -5               # invalid value
+
+try:
+    await product.replace()
+except ValidationError as e:
+    print(e)
+    # Handle or log the error; the document is unchanged in the DB
+```
+
+## Using Custom Pydantic Validators
+
+`validate_on_save` is fully compatible with Pydantic field validators and model
+validators.  They run as part of the re-parse step:
+
+```python
+from pydantic import field_validator, model_validator
+from beanie import Document
+
+
+class Order(Document):
+    quantity: int
+    unit_price: float
+    total: float = 0.0
+
+    class Settings:
+        name = "orders"
+        validate_on_save = True
+
+    @field_validator("quantity")
+    @classmethod
+    def quantity_must_be_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("quantity must be greater than zero")
+        return v
+
+    @model_validator(mode="after")
+    def compute_total(self) -> "Order":
+        self.total = self.quantity * self.unit_price
+        return self
+
+
+order = Order(quantity=3, unit_price=9.99)
+await order.insert()             # total is computed and validated on insert
+
+order.quantity = 0
+await order.save()               # raises ValidationError: quantity must be > 0
+```
+
+## Triggering Validation Without Saving
+
+You can run the full validation pass manually without persisting the document:
+
+```python
+await product.validate_self()
+```
+
+This fires `before_event(ValidateOnSave)` / `after_event(ValidateOnSave)`
+hooks and re-parses the document, but does not write anything to the database.
+
+## Validate-on-Save vs. `validate_assignment`
+
+| Feature | `validate_assignment = True` | `validate_on_save = True` |
+|---|---|---|
+| When validation runs | On every field assignment | Only before a write operation |
+| Performance cost | Per-assignment | Per-write |
+| Catches errors | Immediately on assignment | At write time |
+| Works with `save_changes()` | Yes | Yes |
+| Works with bulk writes | Limited | Yes |
+
+Use `validate_on_save` when you want the safety of full validation before
+persistence without paying the per-assignment cost.  Use `validate_assignment`
+when you want immediate feedback on every field change (e.g. in interactive
+forms or API request models).

--- a/docs/tutorial/revision.md
+++ b/docs/tutorial/revision.md
@@ -1,40 +1,144 @@
 # Revision
 
-This feature helps with concurrent operations. 
-It stores `revision_id` together with the document and changes it on each document update. 
-If the application with an older local copy of the document tries to change it, an exception will be raised. 
-Only when the local copy is synced with the database, the application will be allowed to change the data. 
-This helps to avoid data losses.
+## What is Revision?
 
-### Be aware
-revision id feature may work incorrectly with BulkWriter.
+The revision feature protects against **lost updates** in concurrent
+environments.  Each document stores a `revision_id` (a UUID) that changes on
+every write.  Before Beanie writes a change, it checks that the local
+`revision_id` still matches the one in the database.  If another process
+updated the document in the meantime, the IDs will differ and Beanie raises
+`RevisionIdWasChanged` — preventing one write from silently overwriting
+another.
 
-### Usage
+```
+Process A reads doc   →  revision_id = "abc"
+Process B reads doc   →  revision_id = "abc"
 
-This feature must be explicitly turned on in the `Settings` inner class:
+Process A writes doc  →  revision_id becomes "xyz"
+
+Process B tries to write  →  local "abc" ≠ DB "xyz"  →  RevisionIdWasChanged 🛑
+```
+
+---
+
+## Enabling Revision
+
+Set `use_revision = True` in the document's `Settings` class:
 
 ```python
-class Sample(Document):
-    num: int
-    name: str
+from beanie import Document
+
+
+class BankAccount(Document):
+    owner: str
+    balance: float
 
     class Settings:
+        name = "bank_accounts"
         use_revision = True
 ```
 
-Any changing operation will check if the local copy of the document has the up-to-date `revision_id` value:
+---
+
+## Basic Usage
+
+Once enabled, all mutating operations (`save`, `replace`, `save_changes`,
+`update`) automatically check and update `revision_id`:
 
 ```python
-s = await Sample.find_one(Sample.name="TestName")
-s.num = 10
+account = await BankAccount.find_one(BankAccount.owner == "Alice")
+account.balance += 100.0
 
-# If a concurrent process already changed the doc, the next operation will raise an error
-await s.replace()
+# Succeeds if no other process has modified the document since we read it
+await account.save()
 ```
 
-If you want to ignore revision and apply all the changes even if the local copy is outdated, 
-you can use the `ignore_revision` parameter:
+If a concurrent process modifies the document between our read and our write:
 
 ```python
-await s.replace(ignore_revision=True)
+from beanie.exceptions import RevisionIdWasChanged
+
+try:
+    await account.replace()
+except RevisionIdWasChanged:
+    # Re-fetch the latest version and retry or notify the user
+    account = await BankAccount.find_one(BankAccount.owner == "Alice")
+    account.balance += 100.0
+    await account.replace()
 ```
+
+---
+
+## Ignoring Revision (Force Write)
+
+If you want to overwrite the document regardless of concurrent changes — for
+example in an administrative "last write wins" scenario — pass
+`ignore_revision=True`:
+
+```python
+await account.replace(ignore_revision=True)
+```
+
+> Use this sparingly.  It disables the concurrency protection and can cause
+> data loss.
+
+---
+
+## Retry Pattern
+
+A simple retry loop for optimistic concurrency:
+
+```python
+import asyncio
+from beanie.exceptions import RevisionIdWasChanged
+
+MAX_RETRIES = 3
+
+
+async def credit(owner: str, amount: float) -> None:
+    for attempt in range(MAX_RETRIES):
+        account = await BankAccount.find_one(BankAccount.owner == owner)
+        if account is None:
+            raise ValueError(f"Account for {owner} not found")
+        account.balance += amount
+        try:
+            await account.save()
+            return
+        except RevisionIdWasChanged:
+            if attempt == MAX_RETRIES - 1:
+                raise
+            await asyncio.sleep(0.05 * (attempt + 1))  # brief back-off
+```
+
+---
+
+## How `revision_id` is Stored
+
+The `revision_id` field is a UUID stored in the MongoDB document but excluded
+from Pydantic's public model output (`exclude=True`).  It is managed entirely
+by Beanie and should not be set manually.
+
+When a write succeeds, the new `revision_id` is written back to the in-memory
+instance automatically, so subsequent saves from the same object will use the
+updated token.
+
+---
+
+## Interaction with BulkWriter
+
+> **Warning:** The revision feature may work incorrectly with `BulkWriter`.
+
+`BulkWriter` collects operations and sends them in a single batch, which
+prevents per-document revision checking.  Avoid combining `use_revision = True`
+with `BulkWriter` unless you are certain about the concurrency implications.
+
+---
+
+## Summary
+
+| Scenario | Behaviour |
+|---|---|
+| Concurrent write detected | `RevisionIdWasChanged` raised |
+| Force-write without check | Pass `ignore_revision=True` |
+| `BulkWriter` + revision | Not reliably supported |
+| Revision stored as | `UUID` in `revision_id` field (excluded from schema) |

--- a/docs/tutorial/time_series.md
+++ b/docs/tutorial/time_series.md
@@ -1,8 +1,20 @@
-# Time series
+# Time Series
 
-You can set up a timeseries collection using the inner `Settings` class.
+MongoDB 5.0+ supports native time series collections, which are optimised for
+storing sequences of measurements over time.  Beanie exposes this feature
+through the `TimeSeriesConfig` class.
 
-**Be aware, timeseries collections a supported by MongoDB 5.0 and higher only. The fields `bucket_max_span_seconds` and `bucket_rounding_seconds` however require MongoDB 6.3 or higher**
+> **Requirements**
+>
+> - MongoDB 5.0 or higher for basic time series support.
+> - MongoDB 6.3 or higher for `bucket_max_span_seconds` and
+>   `bucket_rounding_seconds`.
+
+---
+
+## Defining a Time Series Document
+
+Configure a time series collection via the `Settings.timeseries` attribute:
 
 ```python
 from datetime import datetime
@@ -11,21 +23,151 @@ from beanie import Document, TimeSeriesConfig, Granularity
 from pydantic import Field
 
 
-class Sample(Document):
-    ts: datetime = Field(default_factory=datetime.now)
-    meta: str
+class SensorReading(Document):
+    # Required: the field MongoDB uses to bucket measurements by time
+    ts: datetime = Field(default_factory=datetime.utcnow)
+    # Optional metadata field (acts like a "series key" or "tag")
+    sensor_id: str
+    # Measurement value
+    temperature: float
 
     class Settings:
+        name = "sensor_readings"
         timeseries = TimeSeriesConfig(
-            time_field="ts", #  Required
-            meta_field="meta", #  Optional
-            granularity=Granularity.hours, #  Optional
-            bucket_max_span_seconds=3600,  #  Optional
-            bucket_rounding_seconds=3600,  #  Optional
-            expire_after_seconds=2  #  Optional
+            time_field="ts",              # Required — must be a datetime field
+            meta_field="sensor_id",       # Optional — used to identify each series
+            granularity=Granularity.seconds,  # Optional — hours | minutes | seconds
+            expire_after_seconds=86400,   # Optional — TTL: auto-delete after 1 day
         )
 ```
 
-TimeSeriesConfig fields reflect the respective parameters of the MongoDB timeseries creation function.
+### `TimeSeriesConfig` Parameters
 
-MongoDB documentation: https://docs.mongodb.com/manual/core/timeseries-collections/
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `time_field` | `str` | Yes | Name of the `datetime` field used for bucketing |
+| `meta_field` | `str` | No | Name of the field identifying the time series (e.g. device ID) |
+| `granularity` | `Granularity` | No | Bucketing granularity: `hours`, `minutes`, or `seconds` |
+| `expire_after_seconds` | `int` | No | TTL in seconds; documents older than this are deleted automatically |
+| `bucket_max_span_seconds` | `int` | No | Maximum time span per bucket (MongoDB 6.3+) |
+| `bucket_rounding_seconds` | `int` | No | Rounding applied to bucket boundaries (MongoDB 6.3+) |
+
+---
+
+## Inserting Measurements
+
+Time series documents are inserted the same way as regular Beanie documents:
+
+```python
+import asyncio
+from datetime import datetime, timedelta
+
+import motor.motor_asyncio
+from beanie import init_beanie
+
+
+async def main():
+    client = motor.motor_asyncio.AsyncIOMotorClient("mongodb://localhost:27017")
+    await init_beanie(database=client.my_db, document_models=[SensorReading])
+
+    # Insert a single reading
+    reading = SensorReading(sensor_id="sensor-1", temperature=22.4)
+    await reading.insert()
+
+    # Insert many readings at once
+    readings = [
+        SensorReading(
+            ts=datetime.utcnow() - timedelta(minutes=i),
+            sensor_id="sensor-1",
+            temperature=20.0 + i * 0.5,
+        )
+        for i in range(10)
+    ]
+    await SensorReading.insert_many(readings)
+```
+
+> **Note:** Time series collections do **not** support updating or deleting
+> individual documents — they are append-only by design.  Use
+> `expire_after_seconds` for automatic cleanup.
+
+---
+
+## Querying Time Series Data
+
+Query a time series collection exactly like a regular collection:
+
+```python
+from beanie.odm.operators.find.comparison import GTE, LTE
+
+# All readings from the last hour
+one_hour_ago = datetime.utcnow() - timedelta(hours=1)
+recent = await SensorReading.find(
+    SensorReading.ts >= one_hour_ago
+).sort(+SensorReading.ts).to_list()
+
+# Readings for a specific sensor
+sensor_data = await SensorReading.find(
+    SensorReading.sensor_id == "sensor-1"
+).to_list()
+```
+
+### Aggregation Example
+
+```python
+from pydantic import BaseModel, Field
+
+
+class HourlyAverage(BaseModel):
+    hour: str = Field(alias="_id")
+    avg_temp: float
+
+
+hourly = await SensorReading.find(
+    SensorReading.sensor_id == "sensor-1"
+).aggregate(
+    [
+        {
+            "$group": {
+                "_id": {
+                    "$dateToString": {
+                        "format": "%Y-%m-%dT%H:00",
+                        "date": "$ts",
+                    }
+                },
+                "avg_temp": {"$avg": "$temperature"},
+            }
+        },
+        {"$sort": {"_id": 1}},
+    ],
+    projection_model=HourlyAverage,
+).to_list()
+
+for h in hourly:
+    print(f"{h.hour}: {h.avg_temp:.1f}°C")
+```
+
+---
+
+## Granularity Guide
+
+Choose `granularity` based on how frequently you insert data:
+
+| Data frequency | Recommended granularity |
+|---|---|
+| Multiple times per minute | `seconds` |
+| Once per minute to once per hour | `minutes` |
+| Less than once per hour | `hours` |
+
+Setting the correct granularity allows MongoDB to store data more efficiently
+in its internal bucket structure.
+
+---
+
+## Limitations
+
+- Time series collections are **append-only**: individual document updates and
+  deletes are not supported.
+- The `time_field` must be a `datetime` (not `date` or `int`).
+- Time series collections cannot be converted to regular collections (or vice
+  versa) after creation.
+- `BulkWriter` is supported for inserts but not for updates or deletes.


### PR DESCRIPTION
## Summary                                                                                                                                                    
                                                    
  This PR adds first-class support for [Context7](https://context7.com), a platform                                                                             
  that indexes library documentation and serves it to LLM coding assistants (Cursor,                                                                            
  Claude Code, GitHub Copilot, etc.) as up-to-date context. Without this, AI tools                                                                              
  rely on stale training data and frequently generate outdated or incorrect Beanie code.                                                                        
   
  ## Changes                                                                                                                                                    
                                                                       
  ### `context7.json` (new file)

  Adds a configuration file at the repo root that tells Context7 how to index Beanie:                                                                           
   
  - Indexes `docs/` (narrative tutorials) and `beanie/` (source docstrings)                                                                                     
  - Excludes tests, assets, scripts, and boilerplate files             
  - Declares 10 usage rules covering the patterns LLMs most commonly get wrong                                                                                  
    (init, async, relations, hooks, bulk writes, etc.)                                                                                                          
  - References previous versions (`v1.25.0`, `v1.26.0`, `v2.0.0`) for versioned
    doc support                                                                                                                                                 
                                                                       
  ### Docstrings — core modules                                                                                                                                 
                                                                       
  Adds or improves docstrings on previously undocumented public API surface:                                                                                    
                                                                       
  - **`fields.py`** — `DeleteRules`, `WriteRules`, `LinkTypes`, `LinkInfo`, `Link`,                                                                             
    `BackLink`, `ExpressionField`, `IndexModelField` and their key methods
  - **`documents.py`** — `MergeStrategy`, `is_changed`, `has_changed`, `get_changes`,                                                                           
    `get_previous_changes`, `rollback`, `validate_self`, `to_ref`, `fetch_all_links`,                                                                           
    `distinct`, `link_from_id`                                                                                                                                  
  - **`actions.py`** — `EventTypes`, `ActionDirections`                                                                                                         
                                                                                                                                                                
  ### Tutorial expansions                                              

  Six tutorials that were too thin to be useful were rewritten with complete runnable                                                                           
  examples, error handling, and explanatory content:
                                                                                                                                                                
  | Tutorial | Notable additions |                                     
  |---|---|
  | `lazy_parse.md` | When/why to use it, error-timing caveat, caveats table |
  | `delete.md` | `DeleteRules`, cascade, bulk delete, sessions, return value |                                                                                 
  | `on_save_validation.md` | Custom validators, error handling, comparison vs `validate_assignment` |                                                          
  | `aggregate.md` | Built-in methods, complex pipeline examples, aggregation vs find guide |                                                                   
  | `time_series.md` | Insert, query, aggregation examples, `TimeSeriesConfig` parameter reference |                                                            
  | `revision.md` | How the mechanism works, retry pattern, `BulkWriter` warning |                                                                              
                                                                                                                                                                
  ### `docs/cheatsheet.md` (new file)                                                                                                                           
                                                                                                                                                                
  A dense, single-page reference covering every major Beanie feature — setup, CRUD,                                                                             
  relations, hooks, bulk writes, state management, aggregations, indexes, inheritance,
  soft delete, revision, sessions, and migrations. Optimised for LLM context retrieval.
                                                                                                                                                                
  ## Activation
                                                                                                                                                                
  After this PR is merged, submit the repo at https://context7.com/add-library
  (paste the GitHub URL). Context7 will pick up `context7.json` automatically and
  index `docs/` + `beanie/` on the `main` branch.


Closes #1215