### PR TITLE
feat(operators): make operator classes generic for type-safe queries

### DIFF
--- a/beanie/odm/operators/find/array.py
+++ b/beanie/odm/operators/find/array.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -7,7 +7,11 @@ from beanie.odm.operators.find import BaseFindOperator
 class BaseFindArrayOperator(BaseFindOperator, ABC): ...
 
 
-class All(BaseFindArrayOperator):
+_ArrayValuesType = TypeVar("_ArrayValuesType", bound=list[Any])
+_ArrayExpressionType = TypeVar("_ArrayExpressionType", bound=dict[str, Any])
+
+
+class All(BaseFindArrayOperator, Generic[_ArrayValuesType]):
     """
     `$all` array query operator
 
@@ -33,7 +37,7 @@ class All(BaseFindArrayOperator):
     def __init__(
         self,
         field,
-        values: list,
+        values: _ArrayValuesType,
     ):
         self.field = field
         self.values_list = values
@@ -43,7 +47,7 @@ class All(BaseFindArrayOperator):
         return {self.field: {"$all": self.values_list}}
 
 
-class ElemMatch(BaseFindArrayOperator):
+class ElemMatch(BaseFindArrayOperator, Generic[_ArrayExpressionType]):
     """
     `$elemMatch` array query operator
 
@@ -69,7 +73,7 @@ class ElemMatch(BaseFindArrayOperator):
     def __init__(
         self,
         field,
-        expression: dict | None = None,
+        expression: _ArrayExpressionType | None = None,
         **kwargs: Any,
     ):
         self.field = field

--- a/beanie/odm/operators/find/bitwise.py
+++ b/beanie/odm/operators/find/bitwise.py
@@ -1,11 +1,12 @@
-from beanie.odm.fields import ExpressionField
+from typing import Any
+
 from beanie.odm.operators.find import BaseFindOperator
 
 
 class BaseFindBitwiseOperator(BaseFindOperator):
     operator = ""
 
-    def __init__(self, field: str | ExpressionField, bitmask):
+    def __init__(self, field, bitmask: Any):
         self.field = field
         self.bitmask = bitmask
 

--- a/beanie/odm/operators/find/comparison.py
+++ b/beanie/odm/operators/find/comparison.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+from typing import Any
+
 from beanie.odm.operators.find import BaseFindOperator
 
 
@@ -7,13 +10,13 @@ class BaseFindComparisonOperator(BaseFindOperator):
     def __init__(
         self,
         field,
-        other,
+        other: Any,
     ) -> None:
         self.field = field
         self.other = other
 
     @property
-    def query(self):
+    def query(self) -> Mapping[str, Mapping[str, Any]]:
         return {self.field: {self.operator: self.other}}
 
 

--- a/beanie/odm/operators/find/evaluation.py
+++ b/beanie/odm/operators/find/evaluation.py
@@ -1,5 +1,7 @@
 import re
 from abc import ABC
+from collections.abc import Mapping
+from typing import Any, Generic, TypeVar
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -7,7 +9,12 @@ from beanie.odm.operators.find import BaseFindOperator
 class BaseFindEvaluationOperator(BaseFindOperator, ABC): ...
 
 
-class Expr(BaseFindEvaluationOperator):
+_ExpressionExpressionType = TypeVar(
+    "_ExpressionExpressionType", bound=dict[str, Any]
+)
+
+
+class Expr(BaseFindEvaluationOperator, Generic[_ExpressionExpressionType]):
     """
     `$type` query operator
 
@@ -31,7 +38,7 @@ class Expr(BaseFindEvaluationOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/expr/>
     """
 
-    def __init__(self, expression: dict):
+    def __init__(self, expression: _ExpressionExpressionType):
         self.expression = expression
 
     @property
@@ -39,7 +46,9 @@ class Expr(BaseFindEvaluationOperator):
         return {"$expr": self.expression}
 
 
-class JsonSchema(BaseFindEvaluationOperator):
+class JsonSchema(
+    BaseFindEvaluationOperator, Generic[_ExpressionExpressionType]
+):
     """
     `$jsonSchema` query operator
 
@@ -47,7 +56,7 @@ class JsonSchema(BaseFindEvaluationOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/jsonSchema/>
     """
 
-    def __init__(self, expression: dict):
+    def __init__(self, expression: _ExpressionExpressionType):
         self.expression = expression
 
     @property
@@ -84,7 +93,7 @@ class Mod(BaseFindEvaluationOperator):
         self.remainder = remainder
 
     @property
-    def query(self):
+    def query(self) -> Mapping[str, Mapping[str, list[int]]]:
         return {self.field: {"$mod": [self.divisor, self.remainder]}}
 
 

--- a/beanie/odm/operators/find/geospatial.py
+++ b/beanie/odm/operators/find/geospatial.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from enum import Enum
+from typing import Generic, Literal, TypeVar
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -7,7 +8,10 @@ from beanie.odm.operators.find import BaseFindOperator
 class BaseFindGeospatialOperator(BaseFindOperator, ABC): ...
 
 
-class GeoIntersects(BaseFindGeospatialOperator):
+_GeoIntersectsType = TypeVar("_GeoIntersectsType", bound=str)
+
+
+class GeoIntersects(BaseFindGeospatialOperator, Generic[_GeoIntersectsType]):
     """
     `$geoIntersects` query operator
 
@@ -49,7 +53,12 @@ class GeoIntersects(BaseFindGeospatialOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/geoIntersects/>
     """
 
-    def __init__(self, field, geo_type: str, coordinates: list[list[float]]):
+    def __init__(
+        self,
+        field,
+        geo_type: _GeoIntersectsType,
+        coordinates: list[list[float]],
+    ):
         self.field = field
         self.geo_type = geo_type
         self.coordinates = coordinates
@@ -247,7 +256,16 @@ class Near(BaseFindGeospatialOperator):
 
     @property
     def query(self):
-        expression = {
+        expression: dict[
+            str,
+            dict[
+                str,
+                dict[
+                    Literal["$geometry", "$maxDistance", "$minDistance"],
+                    dict[str, str | list[float]] | float,
+                ],
+            ],
+        ] = {
             self.field: {
                 self.operator: {
                     "$geometry": {
@@ -260,11 +278,11 @@ class Near(BaseFindGeospatialOperator):
         if self.max_distance:
             expression[self.field][self.operator]["$maxDistance"] = (
                 self.max_distance
-            )  # type: ignore
+            )
         if self.min_distance:
             expression[self.field][self.operator]["$minDistance"] = (
                 self.min_distance
-            )  # type: ignore
+            )
         return expression
 
 

--- a/beanie/odm/operators/find/logical.py
+++ b/beanie/odm/operators/find/logical.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
 from beanie.odm.operators.find import BaseFindOperator
 
@@ -148,7 +148,7 @@ class Not(BaseFindLogicalOperator):
         self.expression = expression
 
     @property
-    def query(self):
+    def query(self) -> dict[str, dict[Literal["$not"], Any]]:
         if len(self.expression) == 1:
             expression_key = list(self.expression.keys())[0]
             if expression_key.startswith("$"):

--- a/beanie/odm/operators/update/array.py
+++ b/beanie/odm/operators/update/array.py
@@ -1,10 +1,16 @@
+from typing import Any, Generic, TypeVar
+
 from beanie.odm.operators.update import BaseUpdateOperator
 
+_ArrayExpressionType = TypeVar("_ArrayExpressionType", bound=dict[str, Any])
 
-class BaseUpdateArrayOperator(BaseUpdateOperator):
+
+class BaseUpdateArrayOperator(
+    BaseUpdateOperator, Generic[_ArrayExpressionType]
+):
     operator = ""
 
-    def __init__(self, expression):
+    def __init__(self, expression: _ArrayExpressionType):
         self.expression = expression
 
     @property
@@ -12,7 +18,7 @@ class BaseUpdateArrayOperator(BaseUpdateOperator):
         return {self.operator: self.expression}
 
 
-class AddToSet(BaseUpdateArrayOperator):
+class AddToSet(BaseUpdateArrayOperator[_ArrayExpressionType]):
     """
     `$addToSet` update array query operator
 
@@ -38,7 +44,7 @@ class AddToSet(BaseUpdateArrayOperator):
     operator = "$addToSet"
 
 
-class Pop(BaseUpdateArrayOperator):
+class Pop(BaseUpdateArrayOperator[_ArrayExpressionType]):
     """
     `$pop` update array query operator
 
@@ -64,7 +70,7 @@ class Pop(BaseUpdateArrayOperator):
     operator = "$pop"
 
 
-class Pull(BaseUpdateArrayOperator):
+class Pull(BaseUpdateArrayOperator[_ArrayExpressionType]):
     """
     `$pull` update array query operator
 
@@ -90,7 +96,7 @@ class Pull(BaseUpdateArrayOperator):
     operator = "$pull"
 
 
-class Push(BaseUpdateArrayOperator):
+class Push(BaseUpdateArrayOperator[_ArrayExpressionType]):
     """
     `$push` update array query operator
 
@@ -116,7 +122,7 @@ class Push(BaseUpdateArrayOperator):
     operator = "$push"
 
 
-class PullAll(BaseUpdateArrayOperator):
+class PullAll(BaseUpdateArrayOperator[_ArrayExpressionType]):
     """
     `$pullAll` update array query operator
 

--- a/beanie/odm/operators/update/bitwise.py
+++ b/beanie/odm/operators/update/bitwise.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from typing import Any, Generic, TypeVar
 
 from beanie.odm.operators.update import BaseUpdateOperator
 
@@ -6,7 +7,12 @@ from beanie.odm.operators.update import BaseUpdateOperator
 class BaseUpdateBitwiseOperator(BaseUpdateOperator, ABC): ...
 
 
-class Bit(BaseUpdateBitwiseOperator):
+_BitwiseOperatorExpressionType = TypeVar(
+    "_BitwiseOperatorExpressionType", bound=dict[str, Any]
+)
+
+
+class Bit(BaseUpdateBitwiseOperator, Generic[_BitwiseOperatorExpressionType]):
     """
     `$bit` update query operator
 
@@ -14,7 +20,7 @@ class Bit(BaseUpdateBitwiseOperator):
     <https://docs.mongodb.com/manual/reference/operator/update/bit/>
     """
 
-    def __init__(self, expression: dict):
+    def __init__(self, expression: _BitwiseOperatorExpressionType):
         self.expression = expression
 
     @property

--- a/beanie/odm/operators/update/general.py
+++ b/beanie/odm/operators/update/general.py
@@ -1,10 +1,16 @@
+from typing import Any, Generic, TypeVar
+
 from beanie.odm.operators.update import BaseUpdateOperator
 
+_UpdateExpressionType = TypeVar("_UpdateExpressionType", bound=dict[str, Any])
 
-class BaseUpdateGeneralOperator(BaseUpdateOperator):
+
+class BaseUpdateGeneralOperator(
+    BaseUpdateOperator, Generic[_UpdateExpressionType]
+):
     operator = ""
 
-    def __init__(self, expression):
+    def __init__(self, expression: _UpdateExpressionType):
         self.expression = expression
 
     @property
@@ -12,7 +18,7 @@ class BaseUpdateGeneralOperator(BaseUpdateOperator):
         return {self.operator: self.expression}
 
 
-class Set(BaseUpdateGeneralOperator):
+class Set(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$set` update query operator
 
@@ -61,7 +67,7 @@ class SetRevisionId:
     <https://docs.mongodb.com/manual/reference/operator/update/set/>
     """
 
-    def __init__(self, revision_id):
+    def __init__(self, revision_id: Any):
         self.revision_id = revision_id
         self.operator = "$set"
         self.expression = {"revision_id": self.revision_id}
@@ -71,7 +77,7 @@ class SetRevisionId:
         return {self.operator: self.expression}
 
 
-class CurrentDate(BaseUpdateGeneralOperator):
+class CurrentDate(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$currentDate` update query operator
 
@@ -97,7 +103,7 @@ class CurrentDate(BaseUpdateGeneralOperator):
     operator = "$currentDate"
 
 
-class Inc(BaseUpdateGeneralOperator):
+class Inc(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$inc` update query operator
 
@@ -123,7 +129,7 @@ class Inc(BaseUpdateGeneralOperator):
     operator = "$inc"
 
 
-class Min(BaseUpdateGeneralOperator):
+class Min(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$min` update query operator
 
@@ -149,7 +155,7 @@ class Min(BaseUpdateGeneralOperator):
     operator = "$min"
 
 
-class Max(BaseUpdateGeneralOperator):
+class Max(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$max` update query operator
 
@@ -175,7 +181,7 @@ class Max(BaseUpdateGeneralOperator):
     operator = "$max"
 
 
-class Mul(BaseUpdateGeneralOperator):
+class Mul(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$mul` update query operator
 
@@ -201,7 +207,7 @@ class Mul(BaseUpdateGeneralOperator):
     operator = "$mul"
 
 
-class Rename(BaseUpdateGeneralOperator):
+class Rename(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$rename` update query operator
 
@@ -212,7 +218,7 @@ class Rename(BaseUpdateGeneralOperator):
     operator = "$rename"
 
 
-class SetOnInsert(BaseUpdateGeneralOperator):
+class SetOnInsert(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$setOnInsert` update query operator
 
@@ -223,7 +229,7 @@ class SetOnInsert(BaseUpdateGeneralOperator):
     operator = "$setOnInsert"
 
 
-class Unset(BaseUpdateGeneralOperator):
+class Unset(BaseUpdateGeneralOperator[_UpdateExpressionType]):
     """
     `$unset` update query operator
 


### PR DESCRIPTION
Split from https://github.com/BeanieODM/beanie/pull/1303.

Changes:
- Add Generic[T] type parameters to find and update operator base classes and their subclasses, enabling type inference for query expressions.