### PR TITLE
feat: parameterize generic types for strict type checking

### DIFF
--- a/beanie/odm/cache.py
+++ b/beanie/odm/cache.py
@@ -1,27 +1,31 @@
 import collections
 import datetime
 from datetime import timedelta, timezone
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, Field
 
+CachedValueType = TypeVar("CachedValueType", bound=Any)
 
-class CachedItem(BaseModel):
+
+class CachedItem(BaseModel, Generic[CachedValueType]):
     timestamp: datetime.datetime = Field(
         default_factory=lambda: datetime.datetime.now(tz=timezone.utc)
     )
-    value: Any
+    value: CachedValueType
 
 
 class LRUCache:
     def __init__(self, capacity: int, expiration_time: timedelta):
         self.capacity: int = capacity
         self.expiration_time: timedelta = expiration_time
-        self.cache: collections.OrderedDict = collections.OrderedDict()
+        self.cache: collections.OrderedDict[Any, CachedItem[Any]] = (
+            collections.OrderedDict()
+        )
 
-    def get(self, key) -> CachedItem | None:
+    def get(self, key) -> CachedItem[Any] | None:
         try:
-            item: CachedItem = self.cache.pop(key)
+            item: CachedItem[Any] = self.cache.pop(key)
             if (
                 datetime.datetime.now(tz=timezone.utc) - item.timestamp
                 > self.expiration_time

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections import OrderedDict
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -368,7 +369,7 @@ class LinkInfo(BaseModel):
     lookup_field_name: str
     document_class: type[BaseModel]  # Document class
     link_type: LinkTypes
-    nested_links: dict | None = None
+    nested_links: dict[str, "LinkInfo"] | None = None
     is_fetchable: bool = True
 
 
@@ -403,7 +404,7 @@ class Link(Generic[T]):
         :return:
         """
         data = Link.repack_links(links)  # type: ignore
-        ids_to_fetch = []
+        ids_to_fetch: list[DBRef] = []
         document_class = None
         for _doc_id, link in data.items():
             if isinstance(link, Link):
@@ -431,8 +432,10 @@ class Link(Generic[T]):
     @staticmethod
     def repack_links(
         links: list["Link[T] | DocType"],
-    ) -> OrderedDict[Any, Any]:
-        result = OrderedDict()
+    ) -> OrderedDict[Any | PydanticObjectId | None, "Link[Any] | DocType"]:
+        result = OrderedDict[
+            Any | PydanticObjectId | None, Link[Any] | "DocType"
+        ]()
         for link in links:
             if isinstance(link, Link):
                 result[link.ref.id] = link
@@ -442,7 +445,7 @@ class Link(Generic[T]):
 
     @classmethod
     async def fetch_many(cls, links: list["Link[T]"]) -> list["T | Link[T]"]:
-        coros = []
+        coros: list[Coroutine[Any, Any, T | Link[T]]] = []
         for link in links:
             coros.append(link.fetch())
         return await asyncio.gather(*coros)
@@ -605,7 +608,7 @@ class IndexModelField:
     def list_difference(
         left: list["IndexModelField"], right: list["IndexModelField"]
     ):
-        result = []
+        result: list[IndexModelField] = []
         for index in left:
             if index not in right:
                 result.append(index)
@@ -617,7 +620,7 @@ class IndexModelField:
 
     @classmethod
     def from_pymongo_index_information(cls, index_info: dict):
-        result = []
+        result: list[IndexModelField] = []
         for name, details in index_info.items():
             fields = details["key"]
             if ("_id", 1) in fields:

--- a/beanie/odm/interfaces/aggregate.py
+++ b/beanie/odm/interfaces/aggregate.py
@@ -15,7 +15,7 @@ DocumentProjectionType = TypeVar("DocumentProjectionType", bound=BaseModel)
 class AggregateInterface:
     @classmethod
     @abstractmethod
-    def find_all(cls) -> FindMany:
+    def find_all(cls) -> FindMany[BaseModel]:
         pass
 
     @overload

--- a/beanie/odm/interfaces/getters.py
+++ b/beanie/odm/interfaces/getters.py
@@ -1,4 +1,6 @@
 from abc import abstractmethod
+from collections.abc import Mapping
+from typing import Any
 
 from pymongo.asynchronous.collection import AsyncCollection
 
@@ -12,8 +14,8 @@ class OtherGettersInterface:
         pass
 
     @classmethod
-    def get_pymongo_collection(cls) -> AsyncCollection:
-        return cls.get_settings().pymongo_collection
+    def get_pymongo_collection(cls) -> AsyncCollection[Mapping[str, Any]]:
+        return cls.get_settings().pymongo_collection  # type: ignore[return-value]
 
     @classmethod
     def get_collection_name(cls) -> str:

--- a/beanie/odm/interfaces/setters.py
+++ b/beanie/odm/interfaces/setters.py
@@ -1,4 +1,8 @@
-from typing import ClassVar
+from collections.abc import Mapping
+from typing import Any, ClassVar
+
+from pymongo.asynchronous.collection import AsyncCollection
+from pymongo.asynchronous.database import AsyncDatabase
 
 from beanie.odm.settings.document import DocumentSettings
 
@@ -7,22 +11,22 @@ class SettersInterface:
     _document_settings: ClassVar[DocumentSettings | None]
 
     @classmethod
-    def set_collection(cls, collection):
+    def set_collection(cls, collection: AsyncCollection[Mapping[str, Any]]):
         """
         Collection setter
         """
-        cls._document_settings.pymongo_collection = collection
+        cls._document_settings.pymongo_collection = collection  # type: ignore[union-attr]
 
     @classmethod
-    def set_database(cls, database):
+    def set_database(cls, database: AsyncDatabase[Mapping[str, Any]]):
         """
         Database setter
         """
-        cls._document_settings.pymongo_db = database
+        cls._document_settings.pymongo_db = database  # type: ignore[union-attr]
 
     @classmethod
     def set_collection_name(cls, name: str):
         """
         Collection name setter
         """
-        cls._document_settings.name = name  # type: ignore
+        cls._document_settings.name = name  # type: ignore[union-attr]

--- a/beanie/odm/operators/__init__.py
+++ b/beanie/odm/operators/__init__.py
@@ -4,7 +4,7 @@ from copy import copy, deepcopy
 from typing import Any
 
 
-class BaseOperator(Mapping):
+class BaseOperator(Mapping[Any, Any]):
     """
     Base operator.
     """

--- a/beanie/odm/queries/aggregation.py
+++ b/beanie/odm/queries/aggregation.py
@@ -91,7 +91,7 @@ class AggregationQuery(
                 projection_pipeline = [{"$project": projection}]
         return match_pipeline + self.aggregation_pipeline + projection_pipeline
 
-    async def get_cursor(self) -> "AsyncCommandCursor":
+    async def get_cursor(self) -> "AsyncCommandCursor[dict[str, Any]]":
         aggregation_pipeline = self.get_aggregation_pipeline()
         return await self.document_model.get_pymongo_collection().aggregate(
             aggregation_pipeline, session=self.session, **self.pymongo_kwargs

--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -124,7 +124,7 @@ class FindQuery(
             **pymongo_kwargs,
         ).set_session(session=session)
 
-    def project(self, projection_model):
+    def project(self, projection_model) -> "FindQuery":
         """
         Apply projection parameter
         :param projection_model: Optional[type[BaseModel]] - projection model

--- a/beanie/odm/settings/base.py
+++ b/beanie/odm/settings/base.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import timedelta
 from typing import Any
 
@@ -15,8 +16,8 @@ class ItemSettings(BaseModel):
     bson_encoders: dict[Any, Any] = Field(default_factory=dict)
     projection: dict[str, Any] | None = None
 
-    pymongo_db: AsyncDatabase | None = None
-    pymongo_collection: AsyncCollection | None = None
+    pymongo_db: AsyncDatabase[Mapping[str, Any]] | None = None
+    pymongo_collection: AsyncCollection[Mapping[str, Any]] | None = None
 
     union_doc: type | None = None
     union_doc_alias: str | None = None

--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -3,8 +3,12 @@ import inspect
 from importlib.metadata import version
 from types import UnionType
 from typing import (  # noqa: UP035
+    Any,
+    Generic,
     List,
+    Mapping,
     Sequence,
+    TypeVar,
     Union,
     get_args,
     get_origin,
@@ -43,16 +47,18 @@ from beanie.odm.views import View
 
 _DRIVER_METADATA = DriverInfo(name="beanie", version=version("beanie"))
 
+DocumentType = TypeVar("DocumentType", bound=Mapping[str, Any])
+
 
 class Output(BaseModel):
     class_name: str
     collection_name: str
 
 
-class Initializer:
+class Initializer(Generic[DocumentType]):
     def __init__(
         self,
-        database: AsyncDatabase | None = None,
+        database: AsyncDatabase[DocumentType] | None = None,
         connection_string: str | None = None,
         document_models: Sequence[
             type["DocType"] | type["UnionDocType"] | type["View"] | str
@@ -102,7 +108,10 @@ class Initializer:
         ):
             database.client.append_metadata(_DRIVER_METADATA)
 
-        self.database: AsyncDatabase = database  # type: ignore
+        if database is None:
+            raise ValueError("database is required")
+
+        self.database = database
 
         sort_order = {
             ModelType.UnionDoc: 0,
@@ -746,7 +755,7 @@ class Initializer:
 
 
 async def init_beanie(
-    database: AsyncDatabase | None = None,
+    database: AsyncDatabase[DocumentType] | None = None,
     connection_string: str | None = None,
     document_models: Sequence[
         type[Document] | type[UnionDoc] | type["View"] | str


### PR DESCRIPTION
Split from https://github.com/BeanieODM/beanie/pull/1303.

Changes:
- Add type parameters to bare generic types (AsyncDatabase, AsyncCollection, OrderedDict, Mapping, CachedItem, etc.) and related adjustments for stricter type checking compliance.