### PR TITLE
feat: add .exclude() method for exclusion projection on find queries

### DIFF
--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -39,7 +39,8 @@ from beanie.odm.utils.dump import get_dict
 from beanie.odm.utils.encoder import Encoder
 from beanie.odm.utils.find import construct_lookup_queries, split_text_query
 from beanie.odm.utils.parsing import parse_obj
-from beanie.odm.utils.projection import get_projection
+from beanie.odm.utils.projection import get_exclusion_model, get_projection
+from beanie.odm.utils.pydantic import get_model_fields
 from beanie.odm.utils.relations import resolve_query_paths
 
 if TYPE_CHECKING:
@@ -80,6 +81,7 @@ class FindQuery(
         self.lazy_parse = False
         self.nesting_depth: int | None = None
         self.nesting_depths_per_field: dict[str, int] | None = None
+        self._exclude_fields: list[str] = []
 
     def prepare_find_expressions(self):
         if self.document_model.get_link_fields() is not None:
@@ -124,6 +126,92 @@ class FindQuery(
             **pymongo_kwargs,
         ).set_session(session=session)
 
+    # ---- Exclusion projection helpers ----
+    #
+    # Data flow:
+    #   .exclude("id", Sample.float_num, "_id")
+    #       ↓  _to_python_name() normalises each input
+    #   _exclude_fields = ["id", "float_num"]   (canonical Python names)
+    #       ↓                          ↓
+    #   _excluded_db_fields()      get_exclusion_model()
+    #   → ["_id", "float_num"]     → model with Optional fields
+    #   (for MongoDB query)        (for Pydantic parsing)
+
+    def exclude(self, *fields: str) -> "FindQuery[FindQueryResultType]":
+        """
+        Exclude specific fields from query results (exclusion projection).
+
+        Accepts Python field names, MongoDB aliases, or ExpressionField
+        references — all are normalised to Python field names internally.
+        Multiple calls accumulate.
+
+        Cannot be combined with ``.project()``.
+
+        :param fields: field names to exclude from results
+        :return: self
+        """
+        if (
+            self.projection_model is not None
+            and self.projection_model is not self.document_model
+        ):
+            raise ValueError(
+                "Cannot use exclude() together with project(). "
+                "MongoDB does not allow mixing inclusion and exclusion projections."
+            )
+        for field in fields:
+            python_name = self._to_python_name(field)
+            if python_name not in self._exclude_fields:
+                self._exclude_fields.append(python_name)
+        return self
+
+    def _to_python_name(self, field: str) -> str:
+        """Normalise a field reference to its Python field name.
+
+        Handles three input forms:
+        - Python name: ``"id"`` → ``"id"``
+        - MongoDB alias: ``"_id"`` → ``"id"``
+        - ExpressionField: ``Sample.id`` (str value ``"_id"``) → ``"id"``
+
+        Unrecognised names are returned as-is.
+        """
+        model_fields = get_model_fields(self.document_model)
+        if field in model_fields:
+            return field
+        for name, field_info in model_fields.items():
+            if field_info.alias == field:
+                return name
+        return field
+
+    def _excluded_db_fields(self) -> list[str]:
+        """Return ``_exclude_fields`` translated to MongoDB field names."""
+        model_fields = get_model_fields(self.document_model)
+        return [
+            model_fields[f].alias or f if f in model_fields else f
+            for f in self._exclude_fields
+        ]
+
+    def _get_exclusion_projection(self) -> dict[str, int] | None:
+        """Build a MongoDB exclusion projection dict."""
+        if not self._exclude_fields:
+            return None
+        return {f: 0 for f in self._excluded_db_fields()}
+
+    def _get_parse_model(self) -> type[FindQueryResultType]:
+        """Return the model to use for parsing query results.
+
+        When exclusion is active, returns a derived model where excluded
+        fields are ``Optional = None`` so ``model_validate`` succeeds.
+        """
+        if not self._exclude_fields:
+            return self.projection_model
+        return cast(
+            type[FindQueryResultType],
+            get_exclusion_model(
+                self.projection_model,  # type: ignore[arg-type]
+                tuple(self._exclude_fields),
+            ),
+        )
+
     def project(self, projection_model):
         """
         Apply projection parameter
@@ -131,11 +219,16 @@ class FindQuery(
         :return: self
         """
         if projection_model is not None:
+            if self._exclude_fields:
+                raise ValueError(
+                    "Cannot use project() together with exclude(). "
+                    "MongoDB does not allow mixing inclusion and exclusion projections."
+                )
             self.projection_model = projection_model
         return self
 
     def get_projection_model(self) -> type[FindQueryResultType]:
-        return self.projection_model
+        return self._get_parse_model()
 
     async def count(self) -> int:
         """
@@ -298,6 +391,19 @@ class FindMany(
         :return: self
         """
         super().project(projection_model)
+        return self
+
+    def exclude(self, *fields: str) -> "FindMany[FindQueryResultType]":
+        """
+        Exclude specific fields from query results (exclusion projection).
+
+        Cannot be combined with ``.project()``. MongoDB does not allow
+        mixing inclusion and exclusion projections.
+
+        :param fields: field names to exclude from results
+        :return: self
+        """
+        super().exclude(*fields)
         return self
 
     @overload
@@ -592,7 +698,7 @@ class FindMany(
                 "type": "FindMany",
                 "filter": self.get_filter_query(),
                 "sort": self.sort_expressions,
-                "projection": get_projection(self.projection_model),
+                "projection": self._resolve_projection(),
                 "skip": self.skip_number,
                 "limit": self.limit_number,
             }
@@ -664,14 +770,31 @@ class FindMany(
             aggregation_pipeline.append({"$limit": self.limit_number})
         return aggregation_pipeline
 
+    def _resolve_projection(self) -> dict[str, int] | None:
+        """Resolve the effective projection, considering both
+        projection_model and _exclude_fields."""
+        exclusion = self._get_exclusion_projection()
+        if exclusion is not None:
+            return exclusion
+        return get_projection(self.projection_model)
+
     async def get_cursor(
         self,
     ) -> "AsyncCommandCursor[dict[str, Any]] | AsyncCursor[dict[str, Any]] | None":
+        projection = self._resolve_projection()
+
         if self.fetch_links:
             aggregation_pipeline = self.build_aggregation_pipeline()
-            projection = get_projection(self.projection_model)
 
-            if projection is not None:
+            if self._exclude_fields:
+                # Use $unset for exclusion in aggregation pipelines.
+                # $project only reliably supports inclusion for
+                # non-_id fields; $unset is the correct way to remove
+                # fields in an aggregation pipeline.
+                aggregation_pipeline.append(
+                    {"$unset": self._excluded_db_fields()}
+                )
+            elif projection is not None:
                 aggregation_pipeline.append({"$project": projection})
 
             return (
@@ -685,7 +808,7 @@ class FindMany(
         return self.document_model.get_pymongo_collection().find(
             filter=self.get_filter_query(),
             sort=self.sort_expressions,
-            projection=get_projection(self.projection_model),
+            projection=projection,
             skip=self.skip_number,
             limit=self.limit_number,
             session=self.session,
@@ -821,6 +944,19 @@ class FindOne(FindQuery[FindQueryResultType]):
         :return: self
         """
         super().project(projection_model)
+        return self
+
+    def exclude(self, *fields: str) -> "FindOne[FindQueryResultType]":
+        """
+        Exclude specific fields from query results (exclusion projection).
+
+        Cannot be combined with ``.project()``. MongoDB does not allow
+        mixing inclusion and exclusion projections.
+
+        :param fields: field names to exclude from results
+        :return: self
+        """
+        super().exclude(*fields)
         return self
 
     @overload
@@ -1046,7 +1182,7 @@ class FindOne(FindQuery[FindQueryResultType]):
 
     async def _find_one(self):
         if self.fetch_links:
-            return await self.document_model.find_many(
+            find_many_query = self.document_model.find_many(
                 *self.find_expressions,
                 session=self.session,
                 fetch_links=self.fetch_links,
@@ -1054,10 +1190,20 @@ class FindOne(FindQuery[FindQueryResultType]):
                 nesting_depth=self.nesting_depth,
                 nesting_depths_per_field=self.nesting_depths_per_field,
                 **self.pymongo_kwargs,
-            ).first_or_none()
+            )
+            if self._exclude_fields:
+                find_many_query._exclude_fields = list(self._exclude_fields)
+            return await find_many_query.first_or_none()
+
+        exclusion = self._get_exclusion_projection()
+        projection = (
+            exclusion
+            if exclusion is not None
+            else get_projection(self.projection_model)
+        )
         return await self.document_model.get_pymongo_collection().find_one(
             filter=self.get_filter_query(),
-            projection=get_projection(self.projection_model),
+            projection=projection,
             session=self.session,
             **self.pymongo_kwargs,
         )
@@ -1080,6 +1226,7 @@ class FindOne(FindQuery[FindQueryResultType]):
                 self.projection_model,
                 self.session,
                 self.fetch_links,
+                self._exclude_fields,
             )
             document: dict[str, Any] = self.document_model._cache.get(  # type: ignore
                 cache_key
@@ -1091,11 +1238,10 @@ class FindOne(FindQuery[FindQueryResultType]):
             document = yield from self._find_one().__await__()  # type: ignore
         if document is None:
             return None
-        if type(document) is self.projection_model:
+        parse_model = self._get_parse_model()
+        if type(document) is parse_model:
             return cast(FindQueryResultType, document)
-        return cast(
-            FindQueryResultType, parse_obj(self.projection_model, document)
-        )
+        return cast(FindQueryResultType, parse_obj(parse_model, document))
 
     async def count(self) -> int:
         """

--- a/beanie/odm/utils/projection.py
+++ b/beanie/odm/utils/projection.py
@@ -1,6 +1,8 @@
-from typing import TypeVar
+import warnings
+from functools import lru_cache
+from typing import Any, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 from beanie.odm.interfaces.detector import ModelType
 from beanie.odm.utils.pydantic import get_config_value, get_model_fields
@@ -34,3 +36,45 @@ def get_projection(
     for name, field in get_model_fields(model).items():
         document_projection[field.alias or name] = 1
     return document_projection
+
+
+@lru_cache(maxsize=64)
+def get_exclusion_model(
+    base_model: type[ProjectionModelType],
+    exclude_fields: tuple[str, ...],
+) -> type[ProjectionModelType]:
+    """Create a cached model variant where excluded fields become
+    ``Optional[<original_type>] = None``.
+
+    *exclude_fields* must contain **Python field names** (not MongoDB
+    aliases).  Callers are expected to normalise user input before
+    calling this function.
+
+    This allows ``model_validate`` to succeed when MongoDB omits
+    excluded fields from the response.  The returned model is a
+    subclass of *base_model*, so ``isinstance`` checks still pass.
+    """
+    fields = get_model_fields(base_model)
+
+    field_overrides: dict[str, Any] = {}
+    for name in exclude_fields:
+        if name in fields:
+            field_overrides[name] = (
+                fields[name].annotation | None,  # type: ignore[operator]
+                None,
+            )
+
+    if not field_overrides:
+        return base_model  # type: ignore[return-value]
+
+    with warnings.catch_warnings():
+        # Suppress Pydantic "shadows an attribute in parent" warning
+        # that fires when we override fields in the derived model.
+        warnings.filterwarnings(
+            "ignore", message="Field name.*shadows an attribute"
+        )
+        return create_model(  # type: ignore[return-value]
+            f"{base_model.__name__}__Exclusion",
+            __base__=base_model,
+            **field_overrides,
+        )

--- a/docs/tutorial/find.md
+++ b/docs/tutorial/find.md
@@ -229,6 +229,44 @@ chocolates = await Product.find(
     Product.category.name == "Chocolate").project(ProductView).to_list()
 ```
 
+### Exclusion projections
+
+When you want to retrieve everything *except* a few fields, use the `.exclude()` method instead of defining a projection model that lists every field to include:
+
+```python
+# Exclude by field name
+products = await Product.find().exclude("internal_notes", "api_key").to_list()
+
+# Exclude using field references (catches typos at definition time)
+products = await Product.find().exclude(Product.internal_notes).to_list()
+```
+
+`.exclude()` works with `find_one` and `fetch_links` as well:
+
+```python
+product = await Product.find_one(
+    Product.id == product_id
+).exclude("internal_notes")
+
+products = await Product.find(
+    Product.category.name == "Chocolate", fetch_links=True
+).exclude("internal_notes").to_list()
+```
+
+Multiple `.exclude()` calls accumulate:
+
+```python
+# Excludes both fields
+products = await Product.find().exclude("field_a").exclude("field_b").to_list()
+```
+
+`.exclude()` and `.project()` cannot be combined — MongoDB does not allow mixing inclusion and exclusion projections in a single query.
+
+> **Note:** Excluded fields are set to `None` on the returned documents.
+> Saving such a document back to the database will overwrite the real
+> values with `None`. Use `.exclude()` for read-only queries (API
+> responses, reports, etc.).
+
 ### Chaining `.find()` with `fetch_links=True`
 
 You can now safely chain `.find()` calls and preserve the `fetch_links` flag automatically:

--- a/tests/odm/query/test_find.py
+++ b/tests/odm/query/test_find.py
@@ -555,3 +555,146 @@ async def test_distinct_array_field():
     # distinct on an array field should return individual elements, not arrays
     values = await DocumentWithList.find().distinct("list_values")
     assert sorted(values) == ["a", "b", "c", "d"]
+
+
+# --- Exclusion projection tests ---
+
+
+async def test_find_many_with_exclude(preset_documents):
+    """Basic exclusion: excluded fields become None, others are populated.
+    Also verifies that ExpressionField references work as arguments."""
+    # String field names
+    result = (
+        await Sample.find_many(Sample.integer == 0)
+        .exclude("float_num", "geo")
+        .to_list()
+    )
+    assert len(result) > 0
+    for doc in result:
+        assert isinstance(doc, Sample)
+        assert doc.string == "test_0"
+        assert doc.integer == 0
+        assert doc.float_num is None
+        assert doc.geo is None
+
+    # ExpressionField references (Sample.field_name)
+    result2 = (
+        await Sample.find_many(Sample.integer == 0)
+        .exclude(Sample.float_num, Sample.geo)
+        .to_list()
+    )
+    assert len(result2) > 0
+    for doc in result2:
+        assert isinstance(doc, Sample)
+        assert doc.float_num is None
+        assert doc.geo is None
+
+
+async def test_find_one_with_exclude(preset_documents):
+    """Exclusion works with find_one."""
+    doc = await Sample.find_one(Sample.integer == 0).exclude("float_num")
+    assert doc is not None
+    assert isinstance(doc, Sample)
+    assert doc.string == "test_0"
+    assert doc.integer == 0
+    assert doc.float_num is None
+
+
+def test_exclude_with_project_raises():
+    """Using exclude() and project() together raises ValueError."""
+
+    class SampleProjection(BaseModel):
+        string: str
+        integer: int
+
+    with pytest.raises(
+        ValueError, match=r"Cannot use exclude.*together with project"
+    ):
+        Sample.find_many(Sample.integer == 0).project(
+            projection_model=SampleProjection
+        ).exclude("float_num")
+
+    with pytest.raises(
+        ValueError, match=r"Cannot use project.*together with exclude"
+    ):
+        Sample.find_many(Sample.integer == 0).exclude("float_num").project(
+            projection_model=SampleProjection
+        )
+
+
+async def test_find_many_exclude_with_fetch_links():
+    """Exclusion projection works when fetch_links is enabled."""
+    lock = await Lock(k=10).insert()
+    window = await Window(x=1, y=2, lock=lock).insert()
+    door = await Door(t=5, window=window, locks=[lock]).insert()
+    await House(
+        windows=[window], door=door, height=100, name="test_exclude"
+    ).insert()
+
+    result = (
+        await House.find(House.name == "test_exclude", fetch_links=True)
+        .exclude("height")
+        .to_list()
+    )
+    assert len(result) == 1
+    assert isinstance(result[0], House)
+    assert result[0].name == "test_exclude"
+    assert result[0].height is None
+
+
+def test_exclude_clone():
+    """Cloning a query preserves _exclude_fields."""
+    q = Sample.find_many(Sample.integer == 1).exclude("float_num", "geo")
+    cloned = q.clone()
+
+    assert cloned._exclude_fields == ["float_num", "geo"]
+    # Modifying the clone should not affect the original
+    cloned._exclude_fields = []
+    cloned.exclude("string")
+    assert q._exclude_fields == ["float_num", "geo"]
+    assert cloned._exclude_fields == ["string"]
+
+
+def test_exclude_accumulates():
+    """Multiple .exclude() calls accumulate fields, not replace."""
+    q = (
+        Sample.find_many(Sample.integer == 1)
+        .exclude("float_num")
+        .exclude("geo")
+    )
+    assert q._exclude_fields == ["float_num", "geo"]
+
+    # Duplicates are not added
+    q.exclude("float_num")
+    assert q._exclude_fields == ["float_num", "geo"]
+
+
+async def test_exclude_nonexistent_field(preset_documents):
+    """Excluding a field that doesn't exist on the model is silently ignored."""
+    result = (
+        await Sample.find_many(Sample.integer == 0)
+        .exclude("nonexistent_field")
+        .to_list()
+    )
+    assert len(result) > 0
+    for doc in result:
+        assert isinstance(doc, Sample)
+        assert doc.string == "test_0"
+
+
+async def test_find_one_exclude_with_fetch_links():
+    """Exclusion projection works with find_one + fetch_links."""
+    lock = await Lock(k=20).insert()
+    window = await Window(x=3, y=4, lock=lock).insert()
+    door = await Door(t=7, window=window, locks=[lock]).insert()
+    await House(
+        windows=[window], door=door, height=200, name="find_one_exclude"
+    ).insert()
+
+    result = await House.find_one(
+        House.name == "find_one_exclude", fetch_links=True
+    ).exclude("height")
+    assert result is not None
+    assert isinstance(result, House)
+    assert result.name == "find_one_exclude"
+    assert result.height is None


### PR DESCRIPTION
Beanie's `projection_model` only supports inclusion — you define a model listing fields you want. But sometimes you just want to skip a couple of fields (a blob, sensitive data, etc.) without spelling out everything else. MongoDB supports this natively with `{field: 0}`, so this PR exposes it:

```python
products = await Product.find().exclude("internal_notes", "api_key").to_list()
```

Also works with `find_one`, `fetch_links`, and ExpressionField references:

```python
product = await Product.find_one(Product.id == pid).exclude("internal_notes")
products = await Product.find(fetch_links=True).exclude(Product.internal_notes).to_list()
```

Multiple calls accumulate (`.exclude("a").exclude("b")` excludes both), and combining with `.project()` raises `ValueError` since MongoDB doesn't allow mixing inclusion/exclusion.

Related: #163

---

### Implementation notes

The tricky part was parsing. MongoDB returns documents without excluded fields, but `model_validate` fails on missing required fields. The fix: dynamically create a subclass where excluded fields become `Optional[T] = None`, cached via `lru_cache`. The subclass still passes `isinstance` checks.

For `fetch_links=True` (aggregation pipeline), exclusion uses `$unset` instead of `$project` — `$project` with `{field: 0}` is unreliable for non-`_id` fields depending on MongoDB version.

Field names (Python names, MongoDB aliases, ExpressionField references) are all normalised to Python field names at `.exclude()` call time, then converted to MongoDB names only when building the query. This keeps resolution in one place (`_to_python_name`) rather than scattered across query and parsing paths.

> Excluded fields become `None` on returned documents. Saving them back would overwrite real values — intended for read-only use.

### Changes

- `beanie/odm/utils/projection.py` — `get_exclusion_model()`: cached dynamic model creation
- `beanie/odm/queries/find.py` — `.exclude()` on FindQuery/FindMany/FindOne, field name normalisation, `$unset` for aggregation, cache keys
- `docs/tutorial/find.md` — documentation
- `tests/odm/query/test_find.py` — 8 tests (all paths, 577 existing tests pass)