### PR TITLE
Add logical operator typing regression

### DIFF
--- a/tests/typing/find.py
+++ b/tests/typing/find.py
@@ -1,3 +1,4 @@
+from beanie.operators import And, Nor, Or
 from tests.typing.models import ProjectionTest, Test
 
 
@@ -29,3 +30,9 @@ async def find_one() -> Test | None:
 
 async def find_one_with_projection() -> ProjectionTest | None:
     return await Test.find_one().project(projection_model=ProjectionTest)
+
+
+def logical_operators_accept_document_field_comparisons() -> None:
+    Or(Test.foo == "foo", Test.bar == "bar")
+    And(Test.foo == "foo", Test.bar == "bar")
+    Nor(Test.foo == "foo", Test.bar == "bar")


### PR DESCRIPTION
## Summary
- add typing coverage for `Or`, `And`, and `Nor` with document field comparisons
- covers the static type-checking regression reported in #1000

Refs #1000

## Tests
- `uv run --extra test pyright tests/typing/find.py`
- `uv run --extra test ruff check tests/typing/find.py`

Note: `uv run --extra test pytest --rootdir=. tests/odm/operators/find/test_logical.py` could not complete locally because MongoDB was not running on `localhost:27017`; it failed during the shared ODM fixture setup before operator assertions ran.