### PR TITLE
fix: type-annotate update general operators for mypy --strict

### DIFF
--- a/beanie/odm/operators/update/general.py
+++ b/beanie/odm/operators/update/general.py
@@ -1,14 +1,17 @@
+from collections.abc import Mapping
+from typing import Any
+
 from beanie.odm.operators.update import BaseUpdateOperator
 
 
 class BaseUpdateGeneralOperator(BaseUpdateOperator):
     operator = ""
 
-    def __init__(self, expression):
+    def __init__(self, expression: Mapping[Any, Any]) -> None:
         self.expression = expression
 
     @property
-    def query(self):
+    def query(self) -> Mapping[str, Any]:
         return {self.operator: self.expression}
 
 
@@ -61,13 +64,13 @@ class SetRevisionId:
     <https://docs.mongodb.com/manual/reference/operator/update/set/>
     """
 
-    def __init__(self, revision_id):
+    def __init__(self, revision_id: Any) -> None:
         self.revision_id = revision_id
         self.operator = "$set"
         self.expression = {"revision_id": self.revision_id}
 
     @property
-    def query(self):
+    def query(self) -> Mapping[str, Any]:
         return {self.operator: self.expression}
 
 


### PR DESCRIPTION
Closes #946.

## Problem

\`BaseUpdateGeneralOperator.__init__\` and \`SetRevisionId.__init__\` were untyped, so calling \`Set({Sample.one: 2})\` in a \`mypy --strict\` context fires:

\`\`\`
error: Call to untyped function \"Set\" in typed context  [no-untyped-call]
\`\`\`

This is the sibling issue of #836 (which was fixed by #925 for the find comparison operators) but on the update operator side.

## Fix

Annotate the \`__init__\` parameters and the \`query\` property's return type. I used \`Mapping[Any, Any]\` for the \`expression\` argument rather than the more obvious \`Mapping[str, Any]\` so callers using \`ExpressionField\` keys (which subclass \`str\` but are typed as the original field type, e.g. \`int\` in the snippet from the issue) still type-check without spurious \`dict-item\` errors.

## Verification

Reproduced the original error and the fix locally with \`mypy --strict\` against the snippet from the issue body:

\`\`\`bash
# without the fix
$ mypy --strict test_typing_set.py
test_typing_set.py:10: error: Call to untyped function \"Set\" in typed context  [no-untyped-call]
Found 1 error in 1 file (checked 1 source file)

# with the fix
$ mypy --strict test_typing_set.py
Success: no issues found in 1 source file
\`\`\`

7 lines added, 4 lines changed.