### PR TITLE
fix(typing): annotate leftover params on find comparison operators

### DIFF
--- a/beanie/odm/operators/find/comparison.py
+++ b/beanie/odm/operators/find/comparison.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+from typing import Any
+
 from beanie.odm.operators.find import BaseFindOperator
 
 
@@ -6,14 +9,14 @@ class BaseFindComparisonOperator(BaseFindOperator):
 
     def __init__(
         self,
-        field,
-        other,
+        field: Any,
+        other: Any,
     ) -> None:
         self.field = field
         self.other = other
 
     @property
-    def query(self):
+    def query(self) -> Mapping[str, Any]:
         return {self.field: {self.operator: self.other}}
 
 
@@ -41,7 +44,7 @@ class Eq(BaseFindComparisonOperator):
     """
 
     @property
-    def query(self):
+    def query(self) -> Mapping[str, Any]:
         return {self.field: self.other}
 
 


### PR DESCRIPTION
Refs #1050.

The tracking issue lists \`beanie/odm/operators/find/comparison.py\` as a remaining typing leftover from #925, which only added \`-> None\` to \`BaseFindComparisonOperator.__init__\`. The \`field\` and \`other\` parameters and the \`query\` property return type were still bare.

This PR annotates explicitly:

- \`field: Any\`, \`other: Any\` on the constructor.
- \`query\` properties return \`Mapping[str, Any]\` on the base class and on the \`Eq\` override that has its own implementation.

Mirrors the shape we just used for the update-side operators in #1329 (which closed #946, the sibling issue). No runtime change; \`mypy --strict\` treats the explicit annotations the same as the previous implicit-Any, but they're now visible to readers and to stricter checkers (pyright in strict mode flags missing-arg-type).

Net diff: 1 file changed, 7 insertions(+), 4 deletions(-).