### PR TITLE
docs(indexes): clarify that `Annotated[T, Indexed(T, ...)]` is wrong

### DIFF
--- a/docs/tutorial/indexes.md
+++ b/docs/tutorial/indexes.md
@@ -50,6 +50,26 @@ class Sample(Document):
     name: Indexed(str, unique=True)
 ```
 
+!!! warning "Don't pass the type when using `Annotated`"
+
+    The two syntaxes are not interchangeable. When wrapping with
+    `Annotated[...]`, do **not** pass the wrapped type to `Indexed()` —
+    in this position the first positional argument is interpreted as
+    `index_type` (the pymongo index direction / type), so passing
+    `str` silently changes the index meaning and the kwargs you pass
+    (like `unique=True`) won't apply to the field the way you expect.
+
+    ```python
+    # ✓ correct: kwargs go straight to Indexed, type is on Annotated
+    user_id: Annotated[str, Indexed(unique=True)]
+
+    # ✗ wrong: `str` here is treated as `index_type`, not as the field type;
+    # `unique=True` may not be enforced as you expect
+    user_id: Annotated[str, Indexed(str, unique=True)]
+    ```
+
+    Background: [#1036](https://github.com/BeanieODM/beanie/issues/1036).
+
 ### Multi-field indexes
 
 The `indexes` field of the inner `Settings` class is responsible for more complex indexes. 


### PR DESCRIPTION
Refs #1036.

The reporter hit a real trap: \`Annotated[str, Indexed(str, unique=True)]\` *looks* like the \"explicit-type\" shape from the docs (\`Indexed(str, unique=True)\`), but in the \`Annotated\` position the first positional argument to \`Indexed()\` is treated as \`index_type\` (the pymongo index direction / kind), not as the field type. So \`unique=True\` doesn't apply the way the user expects.

@MrEarle explained the right shape in the issue thread:

> When used with \`Annotated\`, you shouldn't provide the type to the \`Indexed\` function. Try this instead:
> \`\`\`python
> user_id: Annotated[str, Indexed(unique=True)]
> \`\`\`

@staticxterm agreed the docs should call this out:

> I believe this ticket should still stay open as at least we should clarify this usage.

This PR adds a \`!!! warning\` callout under the existing \"Indexed in type annotation\" section with:

- The rule (don't pass the type inside \`Annotated[...]\`).
- A side-by-side correct/wrong snippet mirroring the failing example from #1036.
- A link back to the issue.

Pure docs change, 20 lines added.