### PR TITLE
fix: type ExpressionField comparisons for logical operators

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -308,24 +308,24 @@ class ExpressionField(str):
     def __hash__(self):
         return hash(str(self))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> Eq | bool:  # type: ignore[override]
         if isinstance(other, ExpressionField):
             return super().__eq__(other)
         return Eq(field=self, other=other)
 
-    def __gt__(self, other):
+    def __gt__(self, other: object) -> GT:  # type: ignore[override]
         return GT(field=self, other=other)
 
-    def __ge__(self, other):
+    def __ge__(self, other: object) -> GTE:  # type: ignore[override]
         return GTE(field=self, other=other)
 
-    def __lt__(self, other):
+    def __lt__(self, other: object) -> LT:  # type: ignore[override]
         return LT(field=self, other=other)
 
-    def __le__(self, other):
+    def __le__(self, other: object) -> LTE:  # type: ignore[override]
         return LTE(field=self, other=other)
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> NE:  # type: ignore[override]
         return NE(field=self, other=other)
 
     def __pos__(self):

--- a/tests/typing/find.py
+++ b/tests/typing/find.py
@@ -1,3 +1,4 @@
+from beanie.odm.operators.find.logical import And, Nor, Or
 from tests.typing.models import ProjectionTest, Test
 
 
@@ -29,3 +30,11 @@ async def find_one() -> Test | None:
 
 async def find_one_with_projection() -> ProjectionTest | None:
     return await Test.find_one().project(projection_model=ProjectionTest)
+
+
+def logical_operators_accept_comparisons() -> None:
+    Or(Test.foo == "bar", Test.baz == "qux")
+    And(Test.foo == "bar", Test.baz == "qux")
+    Nor(Test.foo == "bar", Test.baz == "qux")
+
+    Or(Test.foo == "bar", Test.baz > "a")


### PR DESCRIPTION
Fixes #1000

## What changed

Add return type annotations to `ExpressionField` comparison operators (`__eq__`, `__gt__`, `__ge__`, `__lt__`, `__le__`, `__ne__`) so type checkers understand that `Product.price < 10` returns a comparison operator object (`LT`), not plain `bool`.

## Why `__eq__` needed special handling

`ExpressionField.__eq__` has dual behavior:
- When comparing two `ExpressionField` instances: returns `bool` (via `str.__eq__`)
- When comparing to any other value: returns `Eq` (query operator)

The annotation `-> Eq | bool` captures both paths. The other operators (`__gt__`, `__ge__`, `__lt__`, `__le__`, `__ne__`) always return their specific comparison type, so they use the concrete return type (e.g., `-> GT`).

Each override includes `# type: ignore[override]` because `ExpressionField` extends `str`, and `str`'s comparison methods return `bool`. This is intentional — the overrides are correct for the query DSL.

## Why `| bool` was kept in logical operators

The `| bool` in `LogicalOperatorForListOfExpressions.__init__` and `Nor.__init__` was left unchanged. The root fix is in `ExpressionField` — making type checkers understand the comparison operators return the right types. Removing `| bool` from logical operators could break backward compatibility for callers who pass actual `bool` values.

## Tests/checks run

```bash
python -c "import beanie"                    # ✅
python -m mypy tests/typing/find.py          # ✅ Success
python -m pyright tests/typing/find.py       # ✅ 0 errors
python -m mypy beanie/odm/fields.py          # ✅ Only pre-existing errors (lines 483, 552)
python -m ruff check beanie/odm/fields.py tests/typing/find.py  # ✅
python -m ruff format --check beanie/odm/fields.py tests/typing/find.py  # ✅
```

## Skipped checks

- Full `pytest` suite requires MongoDB (5.0/7.0/8.0 replica set) — not available in this environment
- Full-repo `pyright` has pre-existing unrelated errors
- `pre-commit run --all-files` requires `pre-commit` to be installed in the environment
