### PR TITLE
docs: add context7.json for LLM documentation indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://context7.com/schema/context7.json",
+    "projectTitle": "Beanie",
+    "description": "Asynchronous Python ODM for MongoDB, built on top of Motor and Pydantic, with a focus on type safety and developer experience.",
+    "folders": [
+        "docs"
+    ],
+    "excludeFolders": [
+        "**/__pycache__",
+        "**/.git"
+    ],
+    "excludeFiles": [
+        "CNAME"
+    ]
+}


### PR DESCRIPTION
## Summary

Adds a `context7.json` configuration file to the repository root so that Context7 can index Beanie's documentation. This enables LLM coding assistants (like Claude Code, Cursor, etc.) to provide better code suggestions when working with Beanie.

Closes #1215

## Changes

- Added `context7.json` to the repository root with:
  - `projectTitle`: "Beanie"
  - `description`: Overview of what Beanie is
  - `folders`: `["docs"]` — includes the docs directory for indexing
  - `excludeFolders`: Standard excludes for `__pycache__` and `.git`
  - `excludeFiles`: `CNAME` file excluded from indexing