### PR TITLE
fix: resolve get_type_hints(Document) NameError

### DIFF
--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -31,6 +31,8 @@ from pymongo.results import (
 )
 from typing_extensions import ParamSpec, Self
 
+import beanie.odm.interfaces.find as find_interface_module
+import beanie.odm.interfaces.inheritance as inheritance_interface_module
 from beanie.exceptions import (
     CollectionWasNotInitialized,
     DocumentNotFound,
@@ -1332,6 +1334,10 @@ class Document(
         return BulkWriter(
             session, ordered, cls, bypass_document_validation, comment
         )
+
+
+find_interface_module.Document = Document
+inheritance_interface_module.Document = Document
 
 
 class DocumentWithSoftDelete(Document):

--- a/beanie/odm/interfaces/find.py
+++ b/beanie/odm/interfaces/find.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from collections.abc import Iterable, Mapping
 from typing import (
@@ -35,7 +37,7 @@ class FindInterface:
 
     _inheritance_inited: bool = False
     _class_id: ClassVar[str | None]
-    _children: ClassVar[dict[str, type["Document"]]]
+    _children: ClassVar[dict[str, type[Document]]]
 
     @classmethod
     @abstractmethod
@@ -67,7 +69,7 @@ class FindInterface:
     def find_one(  # type: ignore
         cls: type[FindType],
         *args: Mapping[Any, Any] | bool,
-        projection_model: type["DocumentProjectionType"],
+        projection_model: type[DocumentProjectionType],
         session: AsyncClientSession | None = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
@@ -75,13 +77,13 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindOne["DocumentProjectionType"]: ...
+    ) -> FindOne[DocumentProjectionType]: ...
 
     @classmethod
     def find_one(  # type: ignore
         cls: type[FindType],
         *args: Mapping[Any, Any] | bool,
-        projection_model: type["DocumentProjectionType"] | None = None,
+        projection_model: type[DocumentProjectionType] | None = None,
         session: AsyncClientSession | None = None,
         ignore_cache: bool = False,
         fetch_links: bool = False,
@@ -89,7 +91,7 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindOne[FindType] | FindOne["DocumentProjectionType"]:
+    ) -> FindOne[FindType] | FindOne[DocumentProjectionType]:
         """
         Find one document by criteria.
         Returns [FindOne](query.md#findone) query object.
@@ -138,7 +140,7 @@ class FindInterface:
     def find_many(  # type: ignore
         cls: type[FindType],
         *args: Mapping[Any, Any] | bool,
-        projection_model: type["DocumentProjectionType"] | None = None,
+        projection_model: type[DocumentProjectionType] | None = None,
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
@@ -150,13 +152,13 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany["DocumentProjectionType"]: ...
+    ) -> FindMany[DocumentProjectionType]: ...
 
     @classmethod
     def find_many(  # type: ignore
         cls: type[FindType],
         *args: Mapping[Any, Any] | bool,
-        projection_model: type["DocumentProjectionType"] | None = None,
+        projection_model: type[DocumentProjectionType] | None = None,
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
@@ -168,7 +170,7 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany[FindType] | FindMany["DocumentProjectionType"]:
+    ) -> FindMany[FindType] | FindMany[DocumentProjectionType]:
         """
         Find many documents by criteria.
         Returns [FindMany](query.md#findmany) query object
@@ -224,7 +226,7 @@ class FindInterface:
     def find(  # type: ignore
         cls: type[FindType],
         *args: Mapping[Any, Any] | bool,
-        projection_model: type["DocumentProjectionType"],
+        projection_model: type[DocumentProjectionType],
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
@@ -236,13 +238,13 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany["DocumentProjectionType"]: ...
+    ) -> FindMany[DocumentProjectionType]: ...
 
     @classmethod
     def find(  # type: ignore
         cls: type[FindType],
         *args: Mapping[Any, Any] | bool,
-        projection_model: type["DocumentProjectionType"] | None = None,
+        projection_model: type[DocumentProjectionType] | None = None,
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
@@ -254,7 +256,7 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany[FindType] | FindMany["DocumentProjectionType"]:
+    ) -> FindMany[FindType] | FindMany[DocumentProjectionType]:
         """
         The same as find_many
         """
@@ -298,7 +300,7 @@ class FindInterface:
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
-        projection_model: type["DocumentProjectionType"] | None = None,
+        projection_model: type[DocumentProjectionType] | None = None,
         session: AsyncClientSession | None = None,
         ignore_cache: bool = False,
         with_children: bool = False,
@@ -306,7 +308,7 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany["DocumentProjectionType"]: ...
+    ) -> FindMany[DocumentProjectionType]: ...
 
     @classmethod
     def find_all(  # type: ignore
@@ -314,7 +316,7 @@ class FindInterface:
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
-        projection_model: type["DocumentProjectionType"] | None = None,
+        projection_model: type[DocumentProjectionType] | None = None,
         session: AsyncClientSession | None = None,
         ignore_cache: bool = False,
         with_children: bool = False,
@@ -322,7 +324,7 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany[FindType] | FindMany["DocumentProjectionType"]:
+    ) -> FindMany[FindType] | FindMany[DocumentProjectionType]:
         """
         Get all the documents
 
@@ -370,7 +372,7 @@ class FindInterface:
     @classmethod
     def all(  # type: ignore
         cls: type[FindType],
-        projection_model: type["DocumentProjectionType"],
+        projection_model: type[DocumentProjectionType],
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
@@ -381,12 +383,12 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany["DocumentProjectionType"]: ...
+    ) -> FindMany[DocumentProjectionType]: ...
 
     @classmethod
     def all(  # type: ignore
         cls: type[FindType],
-        projection_model: type["DocumentProjectionType"] | None = None,
+        projection_model: type[DocumentProjectionType] | None = None,
         skip: int | None = None,
         limit: int | None = None,
         sort: str | list[tuple[str, SortDirection]] | None = None,
@@ -397,7 +399,7 @@ class FindInterface:
         nesting_depth: int | None = None,
         nesting_depths_per_field: dict[str, int] | None = None,
         **pymongo_kwargs: Any,
-    ) -> FindMany[FindType] | FindMany["DocumentProjectionType"]:
+    ) -> FindMany[FindType] | FindMany[DocumentProjectionType]:
         """
         the same as find_all
         """

--- a/beanie/odm/interfaces/inheritance.py
+++ b/beanie/odm/interfaces/inheritance.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
@@ -5,13 +7,13 @@ if TYPE_CHECKING:
 
 
 class InheritanceInterface:
-    _children: ClassVar[dict[str, type["Document"]]]
-    _parent: ClassVar["Document | None"]
+    _children: ClassVar[dict[str, type[Document]]]
+    _parent: ClassVar[Document | None]
     _inheritance_inited: ClassVar[bool]
     _class_id: ClassVar[str | None] = None
 
     @classmethod
-    def add_child(cls, name: str, clas: type["Document"]) -> None:
+    def add_child(cls, name: str, clas: type[Document]) -> None:
         cls._children[name] = clas
         if cls._parent is not None:
             cls._parent.add_child(name, clas)

--- a/tests/odm/test_typing_utils.py
+++ b/tests/odm/test_typing_utils.py
@@ -14,6 +14,14 @@ class Lock(Document):
 
 
 class TestTyping:
+    def test_get_type_hints_document(self):
+        from typing import get_type_hints
+
+        from beanie import Document
+
+        # Should not raise NameError
+        get_type_hints(Document)
+
     def test_extract_id_class(self):
         # Union
         assert extract_id_class(Union[str, int]) is str  # noqa: UP007


### PR DESCRIPTION
Fixes #1335

`get_type_hints(Document)` fails with `NameError: name 'Document' is not defined` in Beanie 2.1.0. The `Document` class inherits from `InheritanceInterface` and `FindInterface`, both of which use string-quoted forward references to `Document` under `TYPE_CHECKING`. When `get_type_hints()` walks the MRO and evaluates these annotations, `Document` is not available in the interface module globals.

## Changes

- Add `from __future__ import annotations` to `beanie/odm/interfaces/find.py` and `beanie/odm/interfaces/inheritance.py` (makes annotations lazy per PEP 563)
- Inject `Document` into the interface module namespaces in `beanie/odm/documents.py` so `get_type_hints()` can resolve the class at runtime
- Add regression test in `tests/odm/test_typing_utils.py`

## Verification

```
python -c "from typing import get_type_hints; from beanie import Document; get_type_hints(Document)"
```

No longer raises `NameError`. Returns 16 type hints successfully.

```
ruff check beanie/odm/interfaces/find.py beanie/odm/interfaces/inheritance.py
```

Clean (0 errors).