### PR TITLE
Fixes BeanieODM#1000 — mypy type compliance for Or() and And() when passing bool values.

### DIFF
--- a/beanie/odm/operators/find/logical.py
+++ b/beanie/odm/operators/find/logical.py
@@ -25,7 +25,10 @@ class LogicalOperatorForListOfExpressions(BaseFindLogicalOperator):
         if not self.expressions:
             raise AttributeError("At least one expression must be provided")
         if len(self.expressions) == 1:
-            return self.expressions[0]
+            expr = self.expressions[0]
+            if isinstance(expr, bool):
+                return {self.operator: [expr]}
+            return expr
         return {self.operator: self.expressions}
 
 

--- a/tests/odm/operators/find/test_logical.py
+++ b/tests/odm/operators/find/test_logical.py
@@ -38,3 +38,25 @@ def test_or():
 
     q = Or(Sample.integer == 1, Sample.nested.integer > 3)
     assert q == {"$or": [{"integer": 1}, {"nested.integer": {"$gt": 3}}]}
+
+
+def test_or_with_bool():
+    """Test that Or() properly handles single bool expression (issue #1000)."""
+    q = Or(True)
+    assert q == {"$or": [True]}
+    assert isinstance(q, dict)
+
+    q = Or(False)
+    assert q == {"$or": [False]}
+    assert isinstance(q, dict)
+
+
+def test_and_with_bool():
+    """Test that And() properly handles single bool expression (issue #1000)."""
+    q = And(True)
+    assert q == {"$and": [True]}
+    assert isinstance(q, dict)
+
+    q = And(False)
+    assert q == {"$and": [False]}
+    assert isinstance(q, dict)

--- a/tests/test_bool_fix_standalone.py
+++ b/tests/test_bool_fix_standalone.py
@@ -1,0 +1,89 @@
+"""Standalone test for the bool type compliance fix (issue #1000).
+Does NOT require MongoDB - tests only the query property output.
+Run with: python -m pytest test_bool_fix_standalone.py -v
+"""
+
+import sys
+
+sys.path.insert(0, "/c/Users/kbula/beanie-fix")
+
+from collections.abc import Mapping
+
+import pytest
+
+from beanie.odm.operators.find.logical import And, Nor, Or
+
+
+class TestBoolTypeCompliance:
+    """Tests for issue #1000: Logical operators should handle bool expressions."""
+
+    def test_or_with_true(self):
+        """Or(True) should return a Mapping, not a bare bool."""
+        q = Or(True).query
+        assert q == {"$or": [True]}
+        assert isinstance(q, Mapping)
+
+    def test_or_with_false(self):
+        """Or(False) should return a Mapping, not a bare bool."""
+        q = Or(False).query
+        assert q == {"$or": [False]}
+        assert isinstance(q, Mapping)
+
+    def test_and_with_true(self):
+        """And(True) should return a Mapping, not a bare bool."""
+        q = And(True).query
+        assert q == {"$and": [True]}
+        assert isinstance(q, Mapping)
+
+    def test_and_with_false(self):
+        """And(False) should return a Mapping, not a bare bool."""
+        q = And(False).query
+        assert q == {"$and": [False]}
+        assert isinstance(q, Mapping)
+
+    def test_or_with_multiple_bool_expressions(self):
+        """Or(True, False) should wrap in $or list."""
+        q = Or(True, False).query
+        assert q == {"$or": [True, False]}
+
+    def test_and_with_multiple_bool_expressions(self):
+        """And(True, False) should wrap in $and list."""
+        q = And(True, False).query
+        assert q == {"$and": [True, False]}
+
+    def test_or_with_dict_expression_unchanged(self):
+        """Or with dict expression should still work as before."""
+        q = Or({"x": 1}).query
+        assert q == {"x": 1}
+
+    def test_or_with_multiple_dict_expressions_unchanged(self):
+        """Or with multiple dict expressions should still work as before."""
+        q = Or({"x": 1}, {"y": 2}).query
+        assert q == {"$or": [{"x": 1}, {"y": 2}]}
+
+    def test_and_with_dict_expression_unchanged(self):
+        """And with dict expression should still work as before."""
+        q = And({"x": 1}).query
+        assert q == {"x": 1}
+
+    def test_nor_with_bool(self):
+        """Nor(True) should return proper dict."""
+        q = Nor(True).query
+        assert q == {"$nor": [True]}
+
+    def test_nor_with_dict_unchanged(self):
+        """Nor with dict expression should still work."""
+        q = Nor({"x": 1}).query
+        assert q == {"$nor": [{"x": 1}]}
+
+    def test_or_empty_query_raises(self):
+        """Or() with no expressions should raise AttributeError on .query access."""
+        op = Or()
+        with pytest.raises(AttributeError, match="At least one expression"):
+            _ = op.query
+
+    def test_and_empty_query_raises(self):
+        """And() with no expressions should raise AttributeError on .query access."""
+        op = And()
+        with pytest.raises(AttributeError, match="At least one expression"):
+            _ = op.query


### PR DESCRIPTION
When Or(True) or And(False) was called with a single bool expression, the query property returned the bare bool directly. Since BaseOperator requires query to return Mapping[str, Any], this caused mypy arg-type errors.