### PR TITLE
Fix index direction float-to-int conversion for existing MongoDB indexes

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -623,12 +623,12 @@ class IndexModelField:
             if ("_id", 1) in fields:
                 continue
 
-            if (
-                fields
-                and isinstance(fields[0][1], float)
-                and (fields[0][1] == 1.0 or fields[0][1] == -1.0)
-            ):
-                fields = [(fields[0][0], int(fields[0][1]))]
+            fields = [
+                (field_name, int(direction))
+                if isinstance(direction, float) and direction in (1.0, -1.0)
+                else (field_name, direction)
+                for field_name, direction in fields
+            ]
 
             options = {k: v for k, v in details.items() if k != "key"}
             index_model = IndexModelField(

--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -623,6 +623,13 @@ class IndexModelField:
             if ("_id", 1) in fields:
                 continue
 
+            if (
+                fields
+                and isinstance(fields[0][1], float)
+                and (fields[0][1] == 1.0 or fields[0][1] == -1.0)
+            ):
+                fields = [(fields[0][0], int(fields[0][1]))]
+
             options = {k: v for k, v in details.items() if k != "key"}
             index_model = IndexModelField(
                 IndexModel(fields, name=name, **options)

--- a/tests/odm/test_fields.py
+++ b/tests/odm/test_fields.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 
 import pytest
 from pydantic import BaseModel, ValidationError
-
 from pymongo import IndexModel
 
 from beanie import Document

--- a/tests/odm/test_fields.py
+++ b/tests/odm/test_fields.py
@@ -231,3 +231,39 @@ def test_from_pymongo_index_information_float_matches_int_index_model():
 def test_index_model_rejects_float_direction_without_conversion():
     with pytest.raises(TypeError):
         IndexModel([("name", 1.0)], name="name_1")
+
+
+def test_from_pymongo_index_information_converts_all_compound_directions():
+    indexes = IndexModelField.from_pymongo_index_information(
+        {
+            "category_1_price_-1": {
+                "v": 2,
+                "key": [("category", 1.0), ("price", -1.0)],
+            },
+        }
+    )
+
+    assert len(indexes) == 1
+    assert indexes[0].index.document["key"] == {
+        "category": 1,
+        "price": -1,
+    }
+    assert isinstance(indexes[0].index.document["key"]["category"], int)
+    assert isinstance(indexes[0].index.document["key"]["price"], int)
+
+
+def test_from_pymongo_index_information_keeps_text_index_direction():
+    indexes = IndexModelField.from_pymongo_index_information(
+        {
+            "name_text": {
+                "v": 2,
+                "key": [("_fts", "text"), ("_ftsx", 1)],
+            },
+        }
+    )
+
+    assert len(indexes) == 1
+    assert indexes[0].index.document["key"] == {
+        "_fts": "text",
+        "_ftsx": 1,
+    }

--- a/tests/odm/test_fields.py
+++ b/tests/odm/test_fields.py
@@ -7,9 +7,11 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from pymongo import IndexModel
+
 from beanie import Document
 from beanie.exceptions import CollectionWasNotInitialized
-from beanie.odm.fields import PydanticObjectId
+from beanie.odm.fields import IndexModelField, PydanticObjectId
 from beanie.odm.utils.dump import get_dict
 from beanie.odm.utils.encoder import Encoder
 from tests.odm.models import (
@@ -176,3 +178,57 @@ def test_indexed_field() -> None:
         uuid_index=uuid4(),
         uuid_index_annotated=uuid4(),
     )
+
+
+def test_from_pymongo_index_information_converts_float_asc_direction():
+    indexes = IndexModelField.from_pymongo_index_information(
+        {
+            "_id_": {"v": 2, "key": [("_id", 1)]},
+            "name_1": {"v": 2, "key": [("name", 1.0)]},
+        }
+    )
+
+    assert len(indexes) == 1
+    assert indexes[0].index.document["key"] == {"name": 1}
+    assert isinstance(indexes[0].index.document["key"]["name"], int)
+
+
+def test_from_pymongo_index_information_converts_float_desc_direction():
+    indexes = IndexModelField.from_pymongo_index_information(
+        {
+            "created_at_-1": {"v": 2, "key": [("created_at", -1.0)]},
+        }
+    )
+
+    assert len(indexes) == 1
+    assert indexes[0].index.document["key"] == {"created_at": -1}
+    assert isinstance(indexes[0].index.document["key"]["created_at"], int)
+
+
+def test_from_pymongo_index_information_keeps_int_direction():
+    indexes = IndexModelField.from_pymongo_index_information(
+        {
+            "email_1": {"v": 2, "key": [("email", 1)], "unique": True},
+        }
+    )
+
+    assert len(indexes) == 1
+    assert indexes[0].index.document["key"] == {"email": 1}
+    assert indexes[0].index.document["unique"] is True
+
+
+def test_from_pymongo_index_information_float_matches_int_index_model():
+    existing = IndexModelField.from_pymongo_index_information(
+        {
+            "status_1": {"v": 2, "key": [("status", 1.0)]},
+        }
+    )
+    declared = IndexModelField(IndexModel([("status", 1)], name="status_1"))
+
+    assert existing[0] == declared
+    assert existing[0].same_fields(declared)
+
+
+def test_index_model_rejects_float_direction_without_conversion():
+    with pytest.raises(TypeError):
+        IndexModel([("name", 1.0)], name="name_1")


### PR DESCRIPTION
## Summary
- Converts float index directions (`1.0` / `-1.0`) returned by MongoDB `index_information()` to ints before building `IndexModel`
- Prevents index comparison / construction failures when existing indexes use float direction values
- Same fix as discussed in https://github.com/BeanieODM/beanie/pull/811, rebased onto current `main` (`from_pymongo_index_information`)

## Test plan
- [ ] Create a document model with a simple ascending/descending index
- [ ] Ensure collection already has matching indexes whose directions are stored as floats
- [ ] Initialize Beanie / sync indexes and confirm no `IndexError` / type mismatch
- [ ] Confirm indexes continue to match and are not unnecessarily recreated