### PR TITLE
Not: accept bool in expression type hint like the other logical ops do

### DIFF
--- a/beanie/odm/operators/find/logical.py
+++ b/beanie/odm/operators/find/logical.py
@@ -144,7 +144,7 @@ class Not(BaseFindLogicalOperator):
     <https://docs.mongodb.com/manual/reference/operator/query/not/>
     """
 
-    def __init__(self, expression: Mapping[str, Any]):
+    def __init__(self, expression: Mapping[str, Any] | bool):
         self.expression = expression
 
     @property


### PR DESCRIPTION
`Or`, `And`, and `Nor` already take `bool` in their `*expressions` hint so things like `Or(Product.price < 10, ...)` typecheck fine. `Not` was typed as `Mapping[str, Any]` only, so `Not(Product.price < 10)` got a mypy error about incompatible argument type.\n\nwidened `Not.__init__`'s parameter to `Mapping[str, Any] | bool` to match the pattern the other operators already use. fixes #1000.