### PR TITLE
fix(typing): preserve awaitable type for find-one upsert

### DIFF
--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -889,7 +889,7 @@ class FindOne(FindQuery[FindQueryResultType]):
         bulk_writer: BulkWriter | None = None,
         response_type: UpdateResponse | None = None,
         **pymongo_kwargs: Any,
-    ):
+    ) -> UpdateOne:
         """
         Create Update with modifications query
         and provide search criteria there
@@ -901,7 +901,8 @@ class FindOne(FindQuery[FindQueryResultType]):
         :return: UpdateMany query
         """
         self.set_session(session)
-        return (
+        return cast(
+            UpdateOne,
             self.UpdateQueryType(
                 document_model=self.document_model,
                 find_query=self.get_filter_query(),
@@ -912,7 +913,7 @@ class FindOne(FindQuery[FindQueryResultType]):
                 response_type=response_type,
                 **pymongo_kwargs,
             )
-            .set_session(session=self.session)
+            .set_session(session=self.session),
         )
 
     def upsert(
@@ -922,7 +923,7 @@ class FindOne(FindQuery[FindQueryResultType]):
         session: AsyncClientSession | None = None,
         response_type: UpdateResponse | None = None,
         **pymongo_kwargs: Any,
-    ):
+    ) -> UpdateOne:
         """
         Create Update with modifications query
         and provide search criteria there
@@ -935,7 +936,8 @@ class FindOne(FindQuery[FindQueryResultType]):
         :return: UpdateMany query
         """
         self.set_session(session)
-        return (
+        return cast(
+            UpdateOne,
             self.UpdateQueryType(
                 document_model=self.document_model,
                 find_query=self.get_filter_query(),
@@ -946,7 +948,7 @@ class FindOne(FindQuery[FindQueryResultType]):
                 response_type=response_type,
                 **pymongo_kwargs,
             )
-            .set_session(session=self.session)
+            .set_session(session=self.session),
         )
 
     def update_one(

--- a/beanie/odm/queries/update.py
+++ b/beanie/odm/queries/update.py
@@ -218,7 +218,7 @@ class UpdateOne(UpdateQuery):
         bulk_writer: BulkWriter | None = None,
         response_type: UpdateResponse | None = None,
         **pymongo_kwargs: Any,
-    ) -> "UpdateQuery":
+    ) -> "UpdateOne":
         """
         Provide modifications to the update query.
 
@@ -245,7 +245,7 @@ class UpdateOne(UpdateQuery):
         session: AsyncClientSession | None = None,
         response_type: UpdateResponse | None = None,
         **pymongo_kwargs: Any,
-    ) -> "UpdateQuery":
+    ) -> "UpdateOne":
         """
         Provide modifications to the upsert query.
 

--- a/tests/typing/find.py
+++ b/tests/typing/find.py
@@ -1,3 +1,4 @@
+from beanie.odm.queries.update import UpdateOne
 from tests.typing.models import ProjectionTest, Test
 
 
@@ -29,3 +30,14 @@ async def find_one() -> Test | None:
 
 async def find_one_with_projection() -> ProjectionTest | None:
     return await Test.find_one().project(projection_model=ProjectionTest)
+
+
+def find_one_update() -> UpdateOne:
+    return Test.find_one().update({"$set": {"bar": "updated"}})
+
+
+def find_one_upsert() -> UpdateOne:
+    return Test.find_one().upsert(
+        {"$set": {"bar": "updated"}},
+        on_insert=Test(foo="foo", bar="bar", baz="baz"),
+    )


### PR DESCRIPTION
Fixes #1342

`FindOne.update()` and `FindOne.upsert()` return the concrete `UpdateOne` query, whose awaitable behavior is available at runtime. The public annotations previously widened the result to `UpdateQuery`, so Pyright rejected valid `await Product.find_one(...).upsert(...)` code.

This keeps the concrete type through the fluent update methods and adds typing coverage for both calls.

Validation:
- pyright tests/typing/find.py
- ruff check and format check for changed files
- python3 -m compileall -q beanie tests/typing/find.py