### PR TITLE
release: 2.2.0

### DIFF
--- a/.github/workflows/github-actions-publish-project.yml
+++ b/.github/workflows/github-actions-publish-project.yml
@@ -1,20 +1,37 @@
 name: Publish project
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing release tag and package version (for example, 2.2.0)"
+        required: true
+        type: string
 jobs:
   publish_project:
+    # Releases are intentionally created only by the project owner.
+    if: github.actor == 'roman-right'
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.version }}
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: verify release tag and version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          test "$(git tag --points-at HEAD)" = "$RELEASE_VERSION"
+          test "$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')" = "$RELEASE_VERSION"
+          test "$(python -c 'from beanie import __version__; print(__version__)')" = "$RELEASE_VERSION"
       - name: install flit
-        run: pip install flit
+        run: python -m pip install flit
       - name: build
         run: flit build
       - name: publish to PyPI

--- a/beanie/__init__.py
+++ b/beanie/__init__.py
@@ -41,7 +41,7 @@ from beanie.odm.utils.update_merge import (
 )
 from beanie.odm.views import View
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 __all__ = [
     # ODM
     "Document",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,33 @@
 
 Beanie project
 
+## [2.2.0] - 2026-08-07
+### Add `distinct()` to chained find queries
+- Author - [smahn9123](https://github.com/smahn9123)
+- PR <https://github.com/BeanieODM/beanie/pull/1301>
+### Optimize `FindQuery.exists()`
+- Author - [gsakkis](https://github.com/gsakkis)
+- PR <https://github.com/BeanieODM/beanie/pull/1295>
+### Fix underscore-prefixed event hooks
+- Author - [tingQian](https://github.com/tingQian)
+- PR <https://github.com/BeanieODM/beanie/pull/1317>
+### Fix typing for `find_one()` upsert results
+- Author - [xianjianlf2](https://github.com/xianjianlf2)
+- PR <https://github.com/BeanieODM/beanie/pull/1346>
+### Fix logical `Not` operator type hint
+- Author - [0x5t4l1n](https://github.com/0x5t4l1n)
+- PR <https://github.com/BeanieODM/beanie/pull/1345>
+### Documentation and examples
+- Add a DocumentDB sample and clarify computed-field and serializer limitations.
+- Add Context7 documentation metadata.
+- Authors - [khelanmodi](https://github.com/khelanmodi), [pctablet505](https://github.com/pctablet505), [Sarthak-commits](https://github.com/Sarthak-commits)
+- PRs <https://github.com/BeanieODM/beanie/pull/1306>, <https://github.com/BeanieODM/beanie/pull/1341>, <https://github.com/BeanieODM/beanie/pull/1334>
+### Documentation: clarify `SetRevisionId` usage
+- Author - [j-vanrav](https://github.com/j-vanrav)
+- PR <https://github.com/BeanieODM/beanie/pull/1315>
+
+[2.2.0]: https://pypi.org/project/beanie/2.2.0
+
 ## [2.1.0] - 2026-03-20
 ### Drop EOL Python 3.9, MongoDB 4.4/5.0/6.0, Pydantic v1
 - Author - [roman-right](https://github.com/roman-right)

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,70 +1,49 @@
 # Publishing a New Version of Beanie
 
-This guide provides step-by-step instructions on how to prepare and publish a new version of Beanie. Before starting, ensure that you have the necessary permissions to update the repository.
+Beanie releases are created manually by the project owner, `roman-right`.
+Merging a pull request or pushing to `main` never publishes a package.
 
-## 1. Prepare a New Version PR
+## Repository and PyPI setup
 
-To publish a new version of Beanie, you need to create a pull request (PR) with the following updates:
+Before the first manual release, configure these controls outside the
+repository:
 
-### 1.1 Update the Version in `pyproject.toml`
+1. Keep `main` protected and do not grant release permissions to other users.
+2. Create a GitHub environment named `pypi` and restrict deployments to
+   `roman-right`.
+3. In PyPI's Trusted Publisher settings for `beanie`, set the owner to
+   `BeanieODM`, repository to `beanie`, workflow file to
+   `github-actions-publish-project.yml`, and environment to `pypi`.
 
-1. Open the [`pyproject.toml`](https://github.com/BeanieODM/beanie/blob/main/pyproject.toml) file.
-2. Update the `version` field to the new version number.
+The workflow also checks the triggering GitHub account and runs only for
+`roman-right`.
 
-### 1.2 Update the Version in the `__init__.py` File
+## Prepare a release
 
-1. Open the [`__init__.py`](https://github.com/BeanieODM/beanie/blob/main/beanie/__init__.py) file.
-2. Update the `__version__` variable to the new version number.
-
-### 1.3 Update the Changelog
-
-To update the changelog, follow these steps:
-
-#### 1.3.1 Set the Version in the Changelog Script
-
-1. Open the [`scripts/generate_changelog.py`](https://github.com/BeanieODM/beanie/blob/main/scripts/generate_changelog.py) file.
-2. Set the `current_version` to the current version and `new_version` to the new version in the script.
-
-#### 1.3.2 Run the Changelog Script
-
-1. Run the following command to generate the updated changelog:
+1. Create a release PR that updates all of the following to the same version:
+   - `pyproject.toml` (`project.version`)
+   - `beanie/__init__.py` (`__version__`)
+   - `docs/changelog.md`
+2. Merge the release PR after the test workflow succeeds.
+3. On the merged commit, create and push an annotated tag whose name exactly
+   matches the package version. For example:
 
    ```bash
-   python scripts/generate_changelog.py
+   git tag -a 2.2.0 -m "Release 2.2.0"
+   git push origin 2.2.0
    ```
 
-2. The script will generate the changelog for the new version.
+## Publish to PyPI
 
-#### 1.3.3 Update the Changelog File
+1. Open the **Publish project** GitHub Actions workflow.
+2. Select **Run workflow**.
+3. Enter the exact tag name, for example `2.2.0`, and run it from `main`.
 
-1. Open the [`changelog.md`](https://github.com/BeanieODM/beanie/blob/main/docs/changelog.md) file.
-2. Copy the generated changelog and paste it at the top of the `changelog.md` file.
+The workflow checks out that immutable tag and verifies that the tag name,
+`pyproject.toml` version, and `beanie.__version__` all match before building
+and publishing with PyPI Trusted Publishing.
 
-### 1.4 Create and Submit the PR
+## Create the GitHub release
 
-Once you have made the necessary updates, create a PR with a descriptive title and summary of the changes. Ensure that all checks pass before merging the PR.
-
-## 2. Publishing the Version
-
-After the PR has been merged, respective GH action will publish it to the PyPI.
-
-## 3. Create a Git Tag and GitHub Release
-
-After the version has been published:
-
-1. Pull the latest changes from the `master` branch:
-   ```bash
-   git pull origin master
-   ```
-
-2. Create a new Git tag with the version number:
-   ```bash
-   git tag -a v1.xx.y -m "Release v1.xx.y"
-   ```
-
-3. Push the tag to the remote repository:
-   ```bash
-   git push origin v1.xx.y
-   ```
-
-4. Create a new release on GitHub using the GitHub interface.
+After a successful PyPI publication, create the matching GitHub release from
+the same tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "beanie"
-version = "2.1.0"
+version = "2.2.0"
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"


### PR DESCRIPTION
## Summary

- Release all changes accumulated since 2.1.0, including chained distinct() support, xists() optimization, event-hook fixes, and typing improvements.
- Bump the package and runtime version to 2.2.0.
- Make PyPI publishing a manual, owner-only release action.

## Validation

- python -m pytest -o addopts='' tests/test_beanie.py -q
- python -m pip wheel . --no-deps

The full Python/MongoDB/Pydantic matrix will run in GitHub Actions.