### PR TITLE
build: derive package version from module

### DIFF
--- a/.github/workflows/github-actions-publish-project.yml
+++ b/.github/workflows/github-actions-publish-project.yml
@@ -2,8 +2,8 @@ name: Publish project
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Existing release tag and package version (for example, 2.2.0)"
+      tag:
+        description: "Existing annotated release tag (for example, 2.2.0)"
         required: true
         type: string
 jobs:
@@ -18,21 +18,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ inputs.version }}
+          ref: refs/tags/${{ inputs.tag }}
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: verify release tag and version
+      - name: verify release tag
         env:
-          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          test "$(git tag --points-at HEAD)" = "$RELEASE_VERSION"
-          test "$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')" = "$RELEASE_VERSION"
-          test "$(python -c 'from beanie import __version__; print(__version__)')" = "$RELEASE_VERSION"
+          git cat-file -e "${RELEASE_TAG}^{tag}"
+          test "$(git rev-parse "${RELEASE_TAG}^{commit}")" = "$(git rev-parse HEAD)"
+          git fetch origin main --quiet
+          git merge-base --is-ancestor HEAD FETCH_HEAD
       - name: install flit
         run: python -m pip install flit
       - name: build
         run: flit build
+      - name: verify built package version
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          python scripts/verify_package_version.py \
+            --wheel dist/*.whl \
+            --expected "$RELEASE_TAG"
       - name: publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -3,6 +3,22 @@ on:
   pull_request:
 
 jobs:
+  verify-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: install build frontend
+        run: python -m pip install build
+      - name: build package
+        run: python -m build
+      - name: verify package version
+        run: python scripts/verify_package_version.py --wheel dist/*.whl
+
   run-tests:
     strategy:
       fail-fast: false

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -37,11 +37,12 @@ The workflow also checks the triggering GitHub account and runs only for
 
 1. Open the **Publish project** GitHub Actions workflow.
 2. Select **Run workflow**.
-3. Enter the exact tag name, for example `2.2.0`, and run it from `main`.
+3. Enter the exact annotated tag name, for example `2.2.0`, and run it from
+   `main`.
 
-The workflow checks out that immutable tag and verifies that the tag name,
-`pyproject.toml` version, and `beanie.__version__` all match before building
-and publishing with PyPI Trusted Publishing.
+The workflow rejects lightweight tags and tags outside `main` history. It then
+checks out the tag, builds the package, and verifies that the wheel metadata
+version matches the tag before publishing with PyPI Trusted Publishing.
 
 ## Create the GitHub release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.11,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]
 name = "beanie"
-version = "2.2.0"
+dynamic = ["version"]
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/scripts/verify_package_version.py
+++ b/scripts/verify_package_version.py
@@ -1,0 +1,66 @@
+"""Verify that a built wheel has the expected module version."""
+
+import argparse
+import ast
+import sys
+import zipfile
+from email.parser import BytesParser
+from pathlib import Path
+
+
+def get_module_version(module_path: Path) -> str:
+    module = ast.parse(module_path.read_text(encoding="utf-8"))
+    for statement in module.body:
+        if not isinstance(statement, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "__version__"
+            for target in statement.targets
+        ):
+            continue
+        if isinstance(statement.value, ast.Constant) and isinstance(
+            statement.value.value, str
+        ):
+            return statement.value.value
+        raise ValueError("__version__ must be a string literal")
+    raise ValueError("__version__ is not defined")
+
+
+def get_wheel_version(wheel_path: Path) -> str:
+    with zipfile.ZipFile(wheel_path) as wheel:
+        metadata_path = next(
+            path
+            for path in wheel.namelist()
+            if path.endswith(".dist-info/METADATA")
+        )
+        metadata = BytesParser().parsebytes(wheel.read(metadata_path))
+    version = metadata["Version"]
+    if version is None:
+        raise ValueError("wheel metadata does not define a version")
+    return version
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wheel", required=True, type=Path)
+    parser.add_argument("--expected")
+    args = parser.parse_args()
+
+    module_version = get_module_version(Path("beanie/__init__.py"))
+    wheel_version = get_wheel_version(args.wheel)
+    expected_version = args.expected or module_version
+
+    if module_version != expected_version or wheel_version != expected_version:
+        raise ValueError(
+            "Version mismatch: "
+            f"module={module_version}, wheel={wheel_version}, "
+            f"expected={expected_version}"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1) from error

--- a/tests/test_beanie.py
+++ b/tests/test_beanie.py
@@ -1,20 +1,5 @@
-import sys
-from pathlib import Path
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
-
 from beanie import __version__
 
 
-def parse_version_from_pyproject():
-    pyproject = Path(__file__).parent.parent / "pyproject.toml"
-    with pyproject.open("rb") as f:
-        toml_data = tomllib.load(f)
-    return toml_data["project"]["version"]
-
-
 def test_version():
-    assert __version__ == parse_version_from_pyproject()
+    assert __version__


### PR DESCRIPTION
Use Flit dynamic versioning so `beanie.__version__` is the only version source.

CI builds a wheel and verifies that its metadata version matches the module version via Python AST. The release workflow accepts only an annotated tag reachable from `main`, then verifies the built wheel version matches that tag before publishing.