### PR TITLE
feat: add .exclude() method for exclusion projection on find queries

### DIFF
--- a/beanie/exceptions.py
+++ b/beanie/exceptions.py
@@ -72,3 +72,10 @@ class Deprecation(Exception):
 
 class ApplyChangesException(Exception):
     pass
+
+
+class DocumentWasPartiallyLoaded(Exception):
+    """Raised when a whole-document write is attempted on a document that
+    was loaded through an exclusion projection (``.exclude()``)."""
+
+    pass

--- a/beanie/odm/documents.py
+++ b/beanie/odm/documents.py
@@ -35,6 +35,7 @@ from beanie.exceptions import (
     CollectionWasNotInitialized,
     DocumentNotFound,
     DocumentWasNotSaved,
+    DocumentWasPartiallyLoaded,
     NotSupported,
     ReplaceError,
     RevisionIdWasChanged,
@@ -290,6 +291,26 @@ class Document(
         else:
             raise ValueError("Invalid merge strategy")
 
+    def _assert_fully_loaded(self, operation: str) -> None:
+        """Refuse whole-document writes on a partially loaded document.
+
+        Documents fetched through an exclusion projection carry ``None``
+        for the excluded fields; writing the whole document back would
+        overwrite the real values. Partial writes (``save_changes``,
+        ``set``, ``update``) stay allowed because they only touch the
+        fields the caller names.
+        """
+        excluded = getattr(type(self), "_beanie_exclusion_fields", None)
+        if excluded:
+            raise DocumentWasPartiallyLoaded(
+                f"Cannot {operation}() a document loaded with "
+                f".exclude({', '.join(repr(f) for f in excluded)}): the "
+                f"excluded fields are None on this instance and would "
+                f"overwrite the stored values. Re-fetch the document "
+                f"without .exclude(), or use save_changes()/set() to "
+                f"write only the fields you changed."
+            )
+
     @validate_self_before
     @wrap_with_actions(EventTypes.INSERT)
     @save_state_after
@@ -306,6 +327,7 @@ class Document(
         :param session: AsyncClientSession - pymongo session
         :return: self
         """
+        self._assert_fully_loaded("insert")
         if self.get_settings().use_revision:
             self.revision_id = uuid4()
         if link_rule is WriteRules.WRITE:
@@ -383,6 +405,7 @@ class Document(
             raise TypeError(
                 "Inserting document must be of the original document class"
             )
+        document._assert_fully_loaded("insert")
         if bulk_writer is None:
             return await document.insert(link_rule=link_rule, session=session)
         else:
@@ -422,14 +445,16 @@ class Document(
             raise NotSupported(
                 "Cascade insert not supported for insert many method"
             )
-        documents_list = [
-            get_dict(
-                document,
-                to_db=True,
-                keep_nulls=document.get_settings().keep_nulls,
+        documents_list = []
+        for document in documents:
+            document._assert_fully_loaded("insert")
+            documents_list.append(
+                get_dict(
+                    document,
+                    to_db=True,
+                    keep_nulls=document.get_settings().keep_nulls,
+                )
             )
-            for document in documents
-        ]
         return await cls.get_pymongo_collection().insert_many(
             documents_list, session=session, **pymongo_kwargs
         )
@@ -454,6 +479,7 @@ class Document(
         :param bulk_writer: "BulkWriter" - Beanie bulk writer
         :return: self
         """
+        self._assert_fully_loaded("replace")
         if self.id is None:
             raise ValueError("Document must have an id")
 
@@ -536,6 +562,7 @@ class Document(
         :param ignore_revision: bool - do force save.
         :return: self
         """
+        self._assert_fully_loaded("save")
         if link_rule is WriteRules.WRITE:
             link_fields = self.get_link_fields()
             if link_fields is not None:

--- a/beanie/odm/queries/cursor.py
+++ b/beanie/odm/queries/cursor.py
@@ -30,6 +30,14 @@ class BaseCursorQuery(Generic[CursorResultType]):
     @abstractmethod
     def get_projection_model(self) -> type[BaseModel] | None: ...
 
+    def get_parse_exclusions(self) -> tuple[str, ...]:
+        """Field paths MongoDB was asked to omit from the response.
+
+        Queries that support exclusion projections override this so the
+        parsing model can be relaxed accordingly.
+        """
+        return ()
+
     @abstractmethod
     async def get_cursor(
         self,
@@ -47,7 +55,12 @@ class BaseCursorQuery(Generic[CursorResultType]):
         projection = self.get_projection_model()
         if projection is None:
             return next_item
-        return parse_obj(projection, next_item, lazy_parse=self.lazy_parse)  # type: ignore
+        return parse_obj(  # type: ignore
+            projection,
+            next_item,
+            lazy_parse=self.lazy_parse,
+            exclude_fields=self.get_parse_exclusions(),
+        )
 
     @abstractmethod
     def _get_cache(self) -> list[dict[str, Any]]: ...
@@ -72,10 +85,16 @@ class BaseCursorQuery(Generic[CursorResultType]):
             self._set_cache(pymongo_list)
         projection = self.get_projection_model()
         if projection is not None:
+            exclude_fields = self.get_parse_exclusions()
             return cast(
                 list[CursorResultType],
                 [
-                    parse_obj(projection, i, lazy_parse=self.lazy_parse)
+                    parse_obj(
+                        projection,
+                        i,
+                        lazy_parse=self.lazy_parse,
+                        exclude_fields=exclude_fields,
+                    )
                     for i in pymongo_list
                 ],
             )

--- a/beanie/odm/queries/find.py
+++ b/beanie/odm/queries/find.py
@@ -6,6 +6,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_args,
     overload,
 )
 
@@ -39,7 +40,8 @@ from beanie.odm.utils.dump import get_dict
 from beanie.odm.utils.encoder import Encoder
 from beanie.odm.utils.find import construct_lookup_queries, split_text_query
 from beanie.odm.utils.parsing import parse_obj
-from beanie.odm.utils.projection import get_projection
+from beanie.odm.utils.projection import get_exclusion_model, get_projection
+from beanie.odm.utils.pydantic import get_model_fields
 from beanie.odm.utils.relations import resolve_query_paths
 
 if TYPE_CHECKING:
@@ -80,6 +82,7 @@ class FindQuery(
         self.lazy_parse = False
         self.nesting_depth: int | None = None
         self.nesting_depths_per_field: dict[str, int] | None = None
+        self._exclude_fields: list[str] = []
 
     def prepare_find_expressions(self):
         if self.document_model.get_link_fields() is not None:
@@ -124,6 +127,152 @@ class FindQuery(
             **pymongo_kwargs,
         ).set_session(session=session)
 
+    # ---- Exclusion projection helpers ----
+    #
+    # Data flow:
+    #   .exclude("id", Sample.float_num, "_id")
+    #       ↓  _resolve_path(db=False) normalises each input
+    #   _exclude_fields = ["id", "float_num"]   (canonical Python paths)
+    #       ↓                                ↓
+    #   _excluded_db_fields()            get_parse_exclusions()
+    #   → ["_id", "float_num"]           → passed to parse_obj(), which
+    #   (for MongoDB query)                 derives the relaxed model
+    #                                       *after* union / inheritance
+    #                                       dispatch has picked the
+    #                                       concrete document class.
+
+    def exclude(self, *fields: str) -> "FindQuery[FindQueryResultType]":
+        """
+        Exclude specific fields from query results (exclusion projection).
+
+        Accepts Python field names, MongoDB aliases, ExpressionField
+        references and dotted paths into embedded models — all are
+        normalised to Python field paths internally.  Multiple calls
+        accumulate.
+
+        Cannot be combined with ``.project()``.
+
+        :param fields: field names to exclude from results
+        :return: self
+        """
+        if self._has_custom_projection_model():
+            raise ValueError(
+                "Cannot use exclude() together with project(). "
+                "MongoDB does not allow mixing inclusion and exclusion projections."
+            )
+        added = False
+        for field in fields:
+            python_path = self._resolve_path(str(field), db=False)
+            if python_path not in self._exclude_fields:
+                self._exclude_fields.append(python_path)
+                added = True
+        if added:
+            self._validate_exclusions()
+        return self
+
+    def _has_custom_projection_model(self) -> bool:
+        return (
+            self.projection_model is not None
+            and self.projection_model is not self.document_model
+        )
+
+    def _exclusion_candidate_models(self) -> list[type[BaseModel]]:
+        """Models a field reference on this query may resolve against.
+
+        For a plain document that is just the document model.  For an
+        inheritance root it also covers the registered children, and for
+        a ``UnionDoc`` — which is not a Pydantic model at all — it is the
+        registered document models.
+        """
+        models: list[type[BaseModel]] = []
+        document_model: Any = self.document_model
+        if isinstance(document_model, type) and issubclass(
+            document_model, BaseModel
+        ):
+            models.append(document_model)
+        for registry in (
+            getattr(document_model, "_children", None),
+            getattr(document_model, "_document_models", None),
+        ):
+            if registry:
+                models.extend(
+                    model for model in registry.values() if model not in models
+                )
+        return models
+
+    @staticmethod
+    def _sub_models(annotation: Any) -> list[type[BaseModel]]:
+        """Models reachable through *annotation* for path traversal."""
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return [annotation]
+        return [
+            arg
+            for arg in get_args(annotation)
+            if isinstance(arg, type) and issubclass(arg, BaseModel)
+        ]
+
+    def _resolve_path(self, field: str, *, db: bool) -> str:
+        """Normalise a (possibly dotted) field reference.
+
+        With ``db=False`` the result is expressed in Python field names,
+        with ``db=True`` in MongoDB names.  Segments that match no known
+        field are passed through untouched, so excluding a field that
+        only exists in the database still works.
+        """
+        segments = field.split(".")
+        models = self._exclusion_candidate_models()
+        resolved: list[str] = []
+
+        for index, segment in enumerate(segments):
+            match: tuple[str, Any] | None = None
+            next_models: list[type[BaseModel]] = []
+            for model in models:
+                model_fields = get_model_fields(model)
+                field_info = model_fields.get(segment)
+                name = segment
+                if field_info is None:
+                    for candidate, info in model_fields.items():
+                        if info.alias == segment:
+                            name, field_info = candidate, info
+                            break
+                if field_info is not None:
+                    if match is None:
+                        match = (name, field_info)
+                    next_models.extend(self._sub_models(field_info.annotation))
+            if match is None:
+                resolved.extend(segments[index:])
+                break
+            name, field_info = match
+            resolved.append((field_info.alias or name) if db else name)
+            models = next_models
+
+        return ".".join(resolved)
+
+    def _validate_exclusions(self) -> None:
+        """Fail fast on exclusion paths that cannot be parsed back.
+
+        ``get_exclusion_model`` raises for dotted paths whose container
+        cannot be rebuilt.  Running it here surfaces the error at
+        ``.exclude()`` time rather than half-way through the query, and
+        the result is cached so it costs nothing later.
+        """
+        exclude_fields = tuple(self._exclude_fields)
+        for model in self._exclusion_candidate_models():
+            get_exclusion_model(model, exclude_fields)  # type: ignore[arg-type]
+
+    def _excluded_db_fields(self) -> list[str]:
+        """Return ``_exclude_fields`` translated to MongoDB field paths."""
+        return [
+            self._resolve_path(field, db=True)
+            for field in self._exclude_fields
+        ]
+
+    def _get_exclusion_projection(self) -> dict[str, int] | None:
+        """Build a MongoDB exclusion projection dict."""
+        if not self._exclude_fields:
+            return None
+        return {f: 0 for f in self._excluded_db_fields()}
+
     def project(self, projection_model):
         """
         Apply projection parameter
@@ -131,11 +280,22 @@ class FindQuery(
         :return: self
         """
         if projection_model is not None:
+            if (
+                self._exclude_fields
+                and projection_model is not self.document_model
+            ):
+                raise ValueError(
+                    "Cannot use project() together with exclude(). "
+                    "MongoDB does not allow mixing inclusion and exclusion projections."
+                )
             self.projection_model = projection_model
         return self
 
     def get_projection_model(self) -> type[FindQueryResultType]:
         return self.projection_model
+
+    def get_parse_exclusions(self) -> tuple[str, ...]:
+        return tuple(self._exclude_fields)
 
     async def count(self) -> int:
         """
@@ -298,6 +458,19 @@ class FindMany(
         :return: self
         """
         super().project(projection_model)
+        return self
+
+    def exclude(self, *fields: str) -> "FindMany[FindQueryResultType]":
+        """
+        Exclude specific fields from query results (exclusion projection).
+
+        Cannot be combined with ``.project()``. MongoDB does not allow
+        mixing inclusion and exclusion projections.
+
+        :param fields: field names to exclude from results
+        :return: self
+        """
+        super().exclude(*fields)
         return self
 
     @overload
@@ -575,6 +748,15 @@ class FindMany(
         :param ignore_cache: bool
         :return:[AggregationQuery](query.md#aggregationquery)
         """
+        if self._exclude_fields:
+            raise ValueError(
+                "Cannot use exclude() together with aggregate(). "
+                "An exclusion projection describes the documents a find "
+                "query returns, which is not well defined for the "
+                "arbitrary output of an aggregation pipeline. Drop the "
+                "excluded fields inside the pipeline instead, for "
+                f"example with {{'$unset': {self._excluded_db_fields()}}}."
+            )
         self.set_session(session=session)
         return self.AggregationQueryType(
             self.document_model,
@@ -592,7 +774,7 @@ class FindMany(
                 "type": "FindMany",
                 "filter": self.get_filter_query(),
                 "sort": self.sort_expressions,
-                "projection": get_projection(self.projection_model),
+                "projection": self._resolve_projection(),
                 "skip": self.skip_number,
                 "limit": self.limit_number,
             }
@@ -664,14 +846,31 @@ class FindMany(
             aggregation_pipeline.append({"$limit": self.limit_number})
         return aggregation_pipeline
 
+    def _resolve_projection(self) -> dict[str, int] | None:
+        """Resolve the effective projection, considering both
+        projection_model and _exclude_fields."""
+        exclusion = self._get_exclusion_projection()
+        if exclusion is not None:
+            return exclusion
+        return get_projection(self.projection_model)
+
     async def get_cursor(
         self,
     ) -> "AsyncCommandCursor[dict[str, Any]] | AsyncCursor[dict[str, Any]] | None":
+        projection = self._resolve_projection()
+
         if self.fetch_links:
             aggregation_pipeline = self.build_aggregation_pipeline()
-            projection = get_projection(self.projection_model)
 
-            if projection is not None:
+            if self._exclude_fields:
+                # Use $unset for exclusion in aggregation pipelines.
+                # $project only reliably supports inclusion for
+                # non-_id fields; $unset is the correct way to remove
+                # fields in an aggregation pipeline.
+                aggregation_pipeline.append(
+                    {"$unset": self._excluded_db_fields()}
+                )
+            elif projection is not None:
                 aggregation_pipeline.append({"$project": projection})
 
             return (
@@ -685,7 +884,7 @@ class FindMany(
         return self.document_model.get_pymongo_collection().find(
             filter=self.get_filter_query(),
             sort=self.sort_expressions,
-            projection=get_projection(self.projection_model),
+            projection=projection,
             skip=self.skip_number,
             limit=self.limit_number,
             session=self.session,
@@ -821,6 +1020,19 @@ class FindOne(FindQuery[FindQueryResultType]):
         :return: self
         """
         super().project(projection_model)
+        return self
+
+    def exclude(self, *fields: str) -> "FindOne[FindQueryResultType]":
+        """
+        Exclude specific fields from query results (exclusion projection).
+
+        Cannot be combined with ``.project()``. MongoDB does not allow
+        mixing inclusion and exclusion projections.
+
+        :param fields: field names to exclude from results
+        :return: self
+        """
+        super().exclude(*fields)
         return self
 
     @overload
@@ -1048,7 +1260,7 @@ class FindOne(FindQuery[FindQueryResultType]):
 
     async def _find_one(self):
         if self.fetch_links:
-            return await self.document_model.find_many(
+            find_many_query = self.document_model.find_many(
                 *self.find_expressions,
                 session=self.session,
                 fetch_links=self.fetch_links,
@@ -1056,10 +1268,20 @@ class FindOne(FindQuery[FindQueryResultType]):
                 nesting_depth=self.nesting_depth,
                 nesting_depths_per_field=self.nesting_depths_per_field,
                 **self.pymongo_kwargs,
-            ).first_or_none()
+            )
+            if self._exclude_fields:
+                find_many_query._exclude_fields = list(self._exclude_fields)
+            return await find_many_query.first_or_none()
+
+        exclusion = self._get_exclusion_projection()
+        projection = (
+            exclusion
+            if exclusion is not None
+            else get_projection(self.projection_model)
+        )
         return await self.document_model.get_pymongo_collection().find_one(
             filter=self.get_filter_query(),
-            projection=get_projection(self.projection_model),
+            projection=projection,
             session=self.session,
             **self.pymongo_kwargs,
         )
@@ -1082,6 +1304,7 @@ class FindOne(FindQuery[FindQueryResultType]):
                 self.projection_model,
                 self.session,
                 self.fetch_links,
+                self.get_parse_exclusions(),
             )
             document: dict[str, Any] = self.document_model._cache.get(  # type: ignore
                 cache_key
@@ -1093,10 +1316,17 @@ class FindOne(FindQuery[FindQueryResultType]):
             document = yield from self._find_one().__await__()  # type: ignore
         if document is None:
             return None
-        if type(document) is self.projection_model:
+        if isinstance(document, BaseModel):
+            # The fetch_links branch of _find_one() delegates to FindMany,
+            # which has already parsed (and relaxed) the document.
             return cast(FindQueryResultType, document)
         return cast(
-            FindQueryResultType, parse_obj(self.projection_model, document)
+            FindQueryResultType,
+            parse_obj(
+                self.projection_model,
+                document,
+                exclude_fields=self.get_parse_exclusions(),
+            ),
         )
 
     async def count(self) -> int:

--- a/beanie/odm/utils/parsing.py
+++ b/beanie/odm/utils/parsing.py
@@ -8,6 +8,7 @@ from beanie.exceptions import (
     UnionHasNoRegisteredDocs,
 )
 from beanie.odm.interfaces.detector import ModelType
+from beanie.odm.utils.projection import get_exclusion_model
 from beanie.odm.utils.pydantic import (
     get_config_value,
     get_model_fields,
@@ -117,7 +118,16 @@ def parse_obj(
     model: type[BaseModel] | type["Document"],
     data: Any,
     lazy_parse: bool = False,
+    exclude_fields: tuple[str, ...] = (),
 ) -> BaseModel:
+    """Parse *data* with *model*.
+
+    *exclude_fields* holds Python field names (optionally dotted paths)
+    that MongoDB was asked to omit from the response.  They are applied
+    **after** union / inheritance dispatch, so that the exclusion model
+    is derived from the concrete class the document actually belongs to
+    rather than from the class the query was issued on.
+    """
     if (
         hasattr(model, "get_model_type")
         and model.get_model_type() is ModelType.UnionDoc  # type: ignore
@@ -136,6 +146,7 @@ def parse_obj(
             model=model._document_models[class_name],  # type: ignore
             data=data,
             lazy_parse=lazy_parse,
+            exclude_fields=exclude_fields,
         )  # type: ignore
     if (
         hasattr(model, "get_model_type")
@@ -154,7 +165,11 @@ def parse_obj(
                 model=model._children[class_name],  # type: ignore
                 data=data,
                 lazy_parse=lazy_parse,
+                exclude_fields=exclude_fields,
             )  # type: ignore
+
+    if exclude_fields:
+        model = get_exclusion_model(model, exclude_fields)  # type: ignore[arg-type]
 
     if (
         lazy_parse

--- a/beanie/odm/utils/projection.py
+++ b/beanie/odm/utils/projection.py
@@ -1,11 +1,17 @@
-from typing import TypeVar
+import warnings
+from copy import copy
+from functools import lru_cache
+from types import UnionType
+from typing import Any, Optional, TypeVar, Union, get_args, get_origin
 
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 from beanie.odm.interfaces.detector import ModelType
 from beanie.odm.utils.pydantic import get_config_value, get_model_fields
 
 ProjectionModelType = TypeVar("ProjectionModelType", bound=BaseModel)
+
+_SEQUENCE_ORIGINS = (list, set, frozenset)
 
 
 def get_projection(
@@ -34,3 +40,143 @@ def get_projection(
     for name, field in get_model_fields(model).items():
         document_projection[field.alias or name] = 1
     return document_projection
+
+
+def _split_exclusion_paths(
+    exclude_fields: tuple[str, ...],
+) -> tuple[set[str], dict[str, tuple[str, ...]]]:
+    """Split dotted exclusion paths into whole-field and nested groups.
+
+    ``("a", "b.c", "b.d")`` becomes ``({"a"}, {"b": ("c", "d")})``.
+    A whole-field exclusion always wins over nested paths below it.
+    """
+    whole: set[str] = set()
+    nested: dict[str, list[str]] = {}
+    for path in exclude_fields:
+        head, _, rest = path.partition(".")
+        if rest:
+            nested.setdefault(head, []).append(rest)
+        else:
+            whole.add(head)
+    return whole, {
+        head: tuple(paths)
+        for head, paths in nested.items()
+        if head not in whole
+    }
+
+
+def _descend_annotation(
+    annotation: Any,
+    sub_paths: tuple[str, ...],
+    owner_name: str,
+    field_name: str,
+) -> Any:
+    """Rebuild *annotation* so that *sub_paths* are excluded inside it.
+
+    Supports models, optional models and sequences of models, including
+    combinations such as ``list[Item] | None``.  Anything else (links,
+    mappings, unions of several models, ...) raises ``ValueError`` --
+    silently ignoring the path would make MongoDB strip the subfield
+    while Pydantic still required it.
+    """
+    origin = get_origin(annotation)
+
+    if origin in (Union, UnionType):
+        variants = [a for a in get_args(annotation) if a is not type(None)]
+        if len(variants) == 1:
+            return Optional[  # noqa: UP045
+                _descend_annotation(
+                    variants[0], sub_paths, owner_name, field_name
+                )
+            ]
+    elif origin in _SEQUENCE_ORIGINS:
+        args = get_args(annotation)
+        if len(args) == 1:
+            return origin[
+                _descend_annotation(args[0], sub_paths, owner_name, field_name)
+            ]
+    elif isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return get_exclusion_model(annotation, sub_paths)
+
+    raise ValueError(
+        f"Cannot exclude nested field(s) "
+        f"{', '.join(f'{field_name}.{p}' for p in sub_paths)!r} on "
+        f"{owner_name}: field {field_name!r} is annotated as "
+        f"{annotation!r}, which beanie cannot rebuild as an exclusion "
+        f"model. Exclude the whole {field_name!r} field instead, or use "
+        f"a projection model."
+    )
+
+
+@lru_cache(maxsize=128)
+def get_exclusion_model(
+    base_model: type[ProjectionModelType],
+    exclude_fields: tuple[str, ...],
+) -> type[ProjectionModelType]:
+    """Create a cached model variant where excluded fields become
+    ``Optional[<original_type>] = None``.
+
+    *exclude_fields* must contain **Python field names** (not MongoDB
+    aliases), optionally as dotted paths into embedded models.  Callers
+    are expected to normalise user input before calling this function.
+
+    This allows ``model_validate`` to succeed when MongoDB omits
+    excluded fields from the response.  The returned model is a
+    subclass of *base_model*, so ``isinstance`` checks still pass.
+
+    Every inherited field is re-declared explicitly, even the ones that
+    are not excluded.  That is deliberate: ``init_beanie`` installs
+    ``ExpressionField`` class attributes on document models, and when
+    Pydantic builds a subclass it picks those up as field *defaults*
+    unless the field is re-declared.  Without this, every field would
+    silently default to the string of its own name.
+    """
+    fields = get_model_fields(base_model)
+    whole, nested = _split_exclusion_paths(exclude_fields)
+    whole &= fields.keys()
+    nested = {k: v for k, v in nested.items() if k in fields}
+
+    if not whole and not nested:
+        return base_model  # type: ignore[return-value]
+
+    field_overrides: dict[str, Any] = {}
+    for name, field_info in fields.items():
+        if name in whole:
+            annotation = (
+                Any if field_info.annotation is None else field_info.annotation
+            )
+            field_overrides[name] = (Optional[annotation], None)  # noqa: UP045
+        elif name in nested:
+            field_overrides[name] = (
+                _descend_annotation(
+                    field_info.annotation,
+                    nested[name],
+                    base_model.__name__,
+                    name,
+                ),
+                copy(field_info),
+            )
+        else:
+            # Re-declared unchanged so Pydantic does not fall back to the
+            # ExpressionField class attribute as this field's default.
+            field_overrides[name] = (field_info.annotation, copy(field_info))
+
+    with warnings.catch_warnings():
+        # Suppress Pydantic "shadows an attribute in parent" warning
+        # that fires when we override fields in the derived model.
+        warnings.filterwarnings(
+            "ignore", message="Field name.*shadows an attribute"
+        )
+        exclusion_model = create_model(
+            f"{base_model.__name__}__Exclusion",
+            __base__=base_model,
+            **field_overrides,
+        )
+
+    # Marks the model as partially loaded. Whole-document writes check
+    # this and refuse, so that excluded fields cannot be silently
+    # written back as None.
+    type.__setattr__(
+        exclusion_model, "_beanie_exclusion_fields", exclude_fields
+    )
+    return exclusion_model  # type: ignore[return-value]

--- a/docs/tutorial/find.md
+++ b/docs/tutorial/find.md
@@ -229,6 +229,66 @@ chocolates = await Product.find(
     Product.category.name == "Chocolate").project(ProductView).to_list()
 ```
 
+### Exclusion projections
+
+When you want to retrieve everything *except* a few fields, use the `.exclude()` method instead of defining a projection model that lists every field to include:
+
+```python
+# Exclude by field name
+products = await Product.find().exclude("internal_notes", "api_key").to_list()
+
+# Exclude using field references (catches typos at definition time)
+products = await Product.find().exclude(Product.internal_notes).to_list()
+```
+
+`.exclude()` works with `find_one` and `fetch_links` as well:
+
+```python
+product = await Product.find_one(
+    Product.id == product_id
+).exclude("internal_notes")
+
+products = await Product.find(
+    Product.category.name == "Chocolate", fetch_links=True
+).exclude("internal_notes").to_list()
+```
+
+Multiple `.exclude()` calls accumulate:
+
+```python
+# Excludes both fields
+products = await Product.find().exclude("field_a").exclude("field_b").to_list()
+```
+
+Dotted paths exclude a single field inside an embedded model, leaving the rest of it intact:
+
+```python
+products = await Product.find().exclude("supplier.contact_email").to_list()
+# product.supplier.contact_email is None, product.supplier.name is populated
+```
+
+Nested exclusion supports embedded models, optional embedded models and lists of them. Paths that beanie cannot rebuild — such as a field typed as a union of several models — raise a `ValueError` from `.exclude()` itself, so the problem surfaces before the query runs.
+
+Documents that use inheritance (`is_root = True`) or a `UnionDoc` are supported: the exclusion is applied to the concrete class each document belongs to, so `with_children=True` queries return properly typed children.
+
+#### Restrictions
+
+`.exclude()` and `.project()` cannot be combined — MongoDB does not allow mixing inclusion and exclusion projections in a single query. Passing the document model itself to `.project()` is still fine, since that is a no-op.
+
+`.exclude()` cannot be combined with `.aggregate()` (or the aggregation helpers `sum`, `avg`, `min`, `max`), because an exclusion projection describes the documents a *find* query returns, which is not well defined for arbitrary pipeline output. Drop the fields inside the pipeline instead:
+
+```python
+await Product.find(...).aggregate([{"$unset": ["internal_notes"]}, ...]).to_list()
+```
+
+> **Note:** Excluded fields are `None` on the returned documents, so beanie
+> refuses whole-document writes on them — `save()`, `replace()` and
+> `insert()` raise `DocumentWasPartiallyLoaded` rather than overwriting the
+> stored values with `None`. Targeted writes such as `save_changes()`,
+> `set()` and `update()` remain available because they only touch the fields
+> you name. Use `.exclude()` for read-oriented queries (API responses,
+> reports, etc.).
+
 ### Chaining `.find()` with `fetch_links=True`
 
 You can now safely chain `.find()` calls and preserve the `fetch_links` flag automatically:

--- a/tests/odm/query/test_find.py
+++ b/tests/odm/query/test_find.py
@@ -4,16 +4,25 @@ from enum import Enum
 import pytest
 from pydantic import BaseModel
 
+from beanie.exceptions import DocumentWasPartiallyLoaded
 from beanie.odm.enums import SortDirection
 from beanie.odm.operators.find.comparison import In
+from beanie.odm.utils.projection import get_exclusion_model
+from beanie.odm.utils.pydantic import get_model_fields
 from tests.odm.models import (
+    Bicycle,
     Color,
+    DocumentMultiModelOne,
+    DocumentTestModel,
+    DocumentUnion,
     DocumentWithBsonEncodersFiledsTypes,
     DocumentWithList,
+    DocumentWithNestedAlias,
     Door,
     House,
     Lock,
     Sample,
+    Vehicle,
     Window,
 )
 
@@ -555,3 +564,337 @@ async def test_distinct_array_field():
     # distinct on an array field should return individual elements, not arrays
     values = await DocumentWithList.find().distinct("list_values")
     assert sorted(values) == ["a", "b", "c", "d"]
+
+
+# --- Exclusion projection tests ---
+
+
+async def test_find_many_with_exclude(preset_documents):
+    """Basic exclusion: excluded fields become None, others are populated.
+    Also verifies that ExpressionField references work as arguments."""
+    # String field names
+    result = (
+        await Sample.find_many(Sample.integer == 0)
+        .exclude("float_num", "geo")
+        .to_list()
+    )
+    assert len(result) > 0
+    for doc in result:
+        assert isinstance(doc, Sample)
+        assert doc.string == "test_0"
+        assert doc.integer == 0
+        assert doc.float_num is None
+        assert doc.geo is None
+
+    # ExpressionField references (Sample.field_name)
+    result2 = (
+        await Sample.find_many(Sample.integer == 0)
+        .exclude(Sample.float_num, Sample.geo)
+        .to_list()
+    )
+    assert len(result2) > 0
+    for doc in result2:
+        assert isinstance(doc, Sample)
+        assert doc.float_num is None
+        assert doc.geo is None
+
+
+async def test_find_one_with_exclude(preset_documents):
+    """Exclusion works with find_one."""
+    doc = await Sample.find_one(Sample.integer == 0).exclude("float_num")
+    assert doc is not None
+    assert isinstance(doc, Sample)
+    assert doc.string == "test_0"
+    assert doc.integer == 0
+    assert doc.float_num is None
+
+
+def test_exclude_with_project_raises():
+    """Using exclude() and project() together raises ValueError."""
+
+    class SampleProjection(BaseModel):
+        string: str
+        integer: int
+
+    with pytest.raises(
+        ValueError, match=r"Cannot use exclude.*together with project"
+    ):
+        Sample.find_many(Sample.integer == 0).project(
+            projection_model=SampleProjection
+        ).exclude("float_num")
+
+    with pytest.raises(
+        ValueError, match=r"Cannot use project.*together with exclude"
+    ):
+        Sample.find_many(Sample.integer == 0).exclude("float_num").project(
+            projection_model=SampleProjection
+        )
+
+
+async def test_exclude_with_fetch_links():
+    """fetch_links runs through an aggregation pipeline, so exclusion is
+    applied with $unset rather than a projection."""
+    lock = await Lock(k=10).insert()
+    window = await Window(x=1, y=2, lock=lock).insert()
+    door = await Door(t=5, window=window, locks=[lock]).insert()
+    await House(
+        windows=[window], door=door, height=100, name="test_exclude"
+    ).insert()
+
+    many = (
+        await House.find(House.name == "test_exclude", fetch_links=True)
+        .exclude("height")
+        .to_list()
+    )
+    assert len(many) == 1
+    assert isinstance(many[0], House)
+    assert many[0].name == "test_exclude"
+    assert many[0].height is None
+    assert many[0].door.t == 5
+
+    one = await House.find_one(
+        House.name == "test_exclude", fetch_links=True
+    ).exclude("height")
+    assert isinstance(one, House)
+    assert one.name == "test_exclude"
+    assert one.height is None
+
+
+def test_exclude_clone():
+    """Cloning a query preserves _exclude_fields."""
+    q = Sample.find_many(Sample.integer == 1).exclude("float_num", "geo")
+    cloned = q.clone()
+
+    assert cloned._exclude_fields == ["float_num", "geo"]
+    # Modifying the clone should not affect the original
+    cloned._exclude_fields = []
+    cloned.exclude("string")
+    assert q._exclude_fields == ["float_num", "geo"]
+    assert cloned._exclude_fields == ["string"]
+
+
+def test_exclude_accumulates():
+    """Multiple .exclude() calls accumulate fields, not replace."""
+    q = (
+        Sample.find_many(Sample.integer == 1)
+        .exclude("float_num")
+        .exclude("geo")
+    )
+    assert q._exclude_fields == ["float_num", "geo"]
+
+    # Duplicates are not added
+    q.exclude("float_num")
+    assert q._exclude_fields == ["float_num", "geo"]
+
+
+async def test_exclude_nonexistent_field(preset_documents):
+    """Excluding a field that doesn't exist on the model is silently ignored."""
+    result = (
+        await Sample.find_many(Sample.integer == 0)
+        .exclude("nonexistent_field")
+        .to_list()
+    )
+    assert len(result) > 0
+    for doc in result:
+        assert isinstance(doc, Sample)
+        assert doc.string == "test_0"
+
+
+def test_exclude_projection_query():
+    """Field references are stored as Python paths and only converted to
+    MongoDB names when the query is built."""
+    q = Sample.find_many().exclude(Sample.id, "float_num")
+    assert q._exclude_fields == ["id", "float_num"]
+    assert q._get_exclusion_projection() == {"_id": 0, "float_num": 0}
+
+    # the MongoDB alias is accepted as input too, and normalises to the
+    # same Python name rather than being added a second time
+    assert Sample.find_many().exclude("_id")._exclude_fields == ["id"]
+
+    # aliases are resolved per segment of a nested path
+    nested = DocumentWithNestedAlias.find_many().exclude(
+        "nested_field.unit_class"
+    )
+    assert nested._get_exclusion_projection() == {"nested_field.unitClass": 0}
+
+
+def test_exclude_preserves_field_defaults():
+    """The generated exclusion model must keep every non-excluded field
+    exactly as declared.
+
+    ``init_beanie`` installs ``ExpressionField`` class attributes on
+    document models.  A naive ``create_model(__base__=...)`` makes
+    Pydantic adopt those as field *defaults*, so every field would
+    silently default to the string of its own name -- and that value
+    would be written back to MongoDB on the next save.
+    """
+    exclusion_model = get_exclusion_model(Sample, ("float_num",))
+
+    for name, field_info in get_model_fields(Sample).items():
+        derived = get_model_fields(exclusion_model)[name]
+        if name == "float_num":
+            assert derived.default is None
+            continue
+        assert derived.default == field_info.default, name
+        assert derived.default_factory is field_info.default_factory, name
+        assert derived.alias == field_info.alias, name
+        assert derived.is_required() == field_info.is_required(), name
+
+    # revision_id is never stored unless use_revision is on, so it is the
+    # field that surfaces the bug on every single excluded document.
+    derived_fields = get_model_fields(exclusion_model)
+    assert derived_fields["revision_id"].default is None
+    assert derived_fields["id"].default is None
+    assert derived_fields["const"].default == "TEST"
+
+
+async def test_exclude_with_inheritance(preset_documents):
+    """Exclusion applies to the concrete child class chosen by the
+    ``_class_id`` dispatch, not to the class the query was issued on."""
+    await Bicycle(color="red", frame=10, wheels=2).insert()
+
+    children = (
+        await Vehicle.find(Vehicle.color == "red", with_children=True)
+        .exclude("frame")
+        .to_list()
+    )
+    assert len(children) == 1
+    assert isinstance(children[0], Bicycle)
+    assert children[0].frame is None
+    assert children[0].wheels == 2
+
+    # querying the child directly keeps working
+    direct = (
+        await Bicycle.find(Bicycle.color == "red").exclude("wheels").to_list()
+    )
+    assert direct[0].wheels is None
+    assert direct[0].frame == 10
+
+
+async def test_exclude_with_union_doc():
+    """A UnionDoc is not a Pydantic model; exclusion must still resolve
+    against the registered document models."""
+    await DocumentMultiModelOne(int_filed=1, shared=11).insert()
+
+    docs = (
+        await DocumentUnion.find(DocumentMultiModelOne.shared == 11)
+        .exclude("int_filed")
+        .to_list()
+    )
+
+    assert len(docs) == 1
+    assert isinstance(docs[0], DocumentMultiModelOne)
+    assert docs[0].int_filed is None
+    assert docs[0].shared == 11
+
+
+async def test_exclude_nested_path(preset_documents):
+    """Dotted paths exclude a field inside an embedded model."""
+    docs = (
+        await Sample.find_many(Sample.integer == 0)
+        .exclude(Sample.nested.integer)
+        .to_list()
+    )
+    assert len(docs) > 0
+    for doc in docs:
+        assert isinstance(doc, Sample)
+        assert doc.nested.integer is None
+        assert doc.nested.option_1 is not None
+        assert doc.float_num is not None
+
+
+def test_exclude_nested_path_unsupported_raises():
+    """A nested path that cannot be rebuilt must fail loudly at
+    .exclude() time rather than blow up during parsing."""
+    with pytest.raises(ValueError, match=r"Cannot exclude nested field"):
+        Sample.find_many().exclude("union.s")
+
+
+async def test_exclude_with_aggregate_raises():
+    """Exclusion is undefined for aggregation output, so combining the
+    two must raise instead of being silently dropped."""
+    with pytest.raises(
+        ValueError, match=r"Cannot use exclude.*together with aggregate"
+    ):
+        Sample.find_many().exclude("float_num").aggregate([{"$count": "n"}])
+
+    # the aggregation helpers route through aggregate() as well
+    with pytest.raises(
+        ValueError, match=r"Cannot use exclude.*together with aggregate"
+    ):
+        await Sample.find_many().exclude("float_num").sum(Sample.float_num)
+
+
+def test_exclude_then_project_document_model_allowed():
+    """project(document_model) is a no-op, so it must not be rejected -
+    exclude() applies the same rule in the opposite order."""
+    q = Sample.find_many(Sample.integer == 0).exclude("float_num")
+    q.project(Sample)
+    assert q._exclude_fields == ["float_num"]
+
+
+async def test_exclude_refuses_whole_document_writes(preset_documents):
+    """Excluded fields are None on the instance; writing the whole
+    document back would overwrite the stored values."""
+    doc = await Sample.find_one(Sample.integer == 0).exclude("float_num")
+    assert doc.float_num is None
+
+    for operation in ("save", "replace", "insert"):
+        with pytest.raises(DocumentWasPartiallyLoaded):
+            await getattr(doc, operation)()
+
+    # targeted writes stay allowed
+    await doc.set({Sample.string: "renamed"})
+    reloaded = await Sample.get(doc.id)
+    assert reloaded.string == "renamed"
+    assert reloaded.float_num is not None
+
+
+async def test_exclude_with_lazy_parse(preset_documents):
+    """lazy_parse builds the document through a different branch of
+    parse_obj, which must see the exclusion too."""
+    docs = (
+        await Sample.find_many(Sample.integer == 0, lazy_parse=True)
+        .exclude("float_num")
+        .to_list()
+    )
+    assert len(docs) > 0
+    for doc in docs:
+        assert isinstance(doc, Sample)
+        assert doc.string == "test_0"
+        assert doc.float_num is None
+
+
+async def test_exclude_is_part_of_the_cache_key(documents):
+    """An excluded and a non-excluded query differ only in their
+    projection, so the cache must not serve one for the other."""
+    await documents(1, "cache_and_exclude")
+
+    full = await DocumentTestModel.find(
+        DocumentTestModel.test_str == "cache_and_exclude"
+    ).to_list()
+    assert full[0].test_int is not None
+
+    excluded = (
+        await DocumentTestModel.find(
+            DocumentTestModel.test_str == "cache_and_exclude"
+        )
+        .exclude("test_int")
+        .to_list()
+    )
+    assert excluded[0].test_int is None
+
+    # ... and the cached full result is still intact afterwards
+    again = await DocumentTestModel.find(
+        DocumentTestModel.test_str == "cache_and_exclude"
+    ).to_list()
+    assert again[0].test_int is not None
+
+    one_full = await DocumentTestModel.find_one(
+        DocumentTestModel.test_str == "cache_and_exclude"
+    )
+    one_excluded = await DocumentTestModel.find_one(
+        DocumentTestModel.test_str == "cache_and_exclude"
+    ).exclude("test_int")
+    assert one_full.test_int is not None
+    assert one_excluded.test_int is None


### PR DESCRIPTION
Beanie's `projection_model` only supports inclusion — you define a model listing every field you want. Sometimes you just want to skip a couple of fields (a large blob, sensitive data) without spelling out all the others. MongoDB supports this natively with `{field: 0}`:

```python
products = await Product.find().exclude("internal_notes", "api_key").to_list()

# find_one, fetch_links, aliases and ExpressionField refs all work;
# repeated calls accumulate; dotted paths reach into embedded models
await Product.find_one(Product.id == pid).exclude(Product.internal_notes)
await Product.find(fetch_links=True).exclude("supplier.contact_email").to_list()
```

Inheritance (`is_root = True`) and `UnionDoc` are supported: the exclusion is applied to the concrete class each document turns out to belong to, so `with_children=True` still returns properly typed children.

Related: #163
Supersedes #1322

## Write protection

Excluded fields are `None` on the returned instance, so writing the whole document back would overwrite the stored values. `save()`, `replace()` and `insert()` therefore raise `DocumentWasPartiallyLoaded` (new in `beanie.exceptions`), while `save_changes()` and `set()` still work since they only touch named fields. The guard fires only on instances produced by an exclusion projection, so no existing behaviour changes.

## Restrictions

Combinations that cannot work raise rather than silently misbehaving: `.project()` with a model other than the document model, `.aggregate()` (and the `sum`/`avg`/`min`/`max` helpers), and nested paths that cannot be rebuilt — the last from `.exclude()` itself, before the query runs.

## Implementation notes

Results are parsed with a cached subclass where the excluded fields become `Optional = None`; it still passes `isinstance` checks. Two details are worth flagging for review:

- **`get_exclusion_model()` re-declares every inherited field, not just the excluded ones.** This looks redundant but is load-bearing: `init_beanie` installs `ExpressionField` class attributes on document models, and Pydantic adopts those as field *defaults* in a subclass unless the field is re-declared. Without it every field defaults to the string of its own name — `revision_id` becomes `"revision_id"`, which lands on every excluded document and is written back on the next save.
- **The exclusion is applied inside `parse_obj`, after union / inheritance dispatch.** Applying it earlier would relax the class the query was issued on, and the `_class_id` dispatch would then hand the document to the original child class, which still requires the excluded field.

`fetch_links=True` runs through an aggregation, where exclusion uses `$unset` rather than `$project`, which is unreliable for non-`_id` fields on some MongoDB versions. Field names are normalised to Python paths at `.exclude()` call time and converted to MongoDB names only when the query is built.

## Tests

18 tests covering query building, parsing, inheritance/`UnionDoc`, nested paths, caching, `lazy_parse`, the restrictions and the write guard. The cache-key and `lazy_parse` tests were checked against deliberately reintroduced regressions to confirm they fail when the behaviour breaks.

Full suite: 596 passed, verified against MongoDB 8.0 with a replica set. `ruff`, `ruff-format` and `mypy` report nothing new versus `main`.
