### PR TITLE
fix: recover from a concurrent insert during upsert (#1350)

### DIFF
--- a/beanie/odm/queries/update.py
+++ b/beanie/odm/queries/update.py
@@ -7,6 +7,7 @@ from pymongo import ReturnDocument
 from pymongo import UpdateMany as UpdateManyPyMongo
 from pymongo import UpdateOne as UpdateOnePyMongo
 from pymongo.asynchronous.client_session import AsyncClientSession
+from pymongo.errors import DuplicateKeyError
 from pymongo.results import InsertOneResult, UpdateResult
 
 from beanie.odm.bulk import BulkWriter
@@ -84,6 +85,31 @@ class UpdateQuery(UpdateMethods, SessionMethods, CloneInterface):
             else:
                 raise TypeError("Wrong expression type")
         return Encoder(custom_encoders=self.encoders).encode(query)
+
+    async def _insert_on_upsert(self) -> Any:
+        """
+        Insert the `on_insert` document, recovering if a concurrent caller
+        inserted a matching document first.
+        """
+        try:
+            return await self.document_model.insert_one(
+                document=self.upsert_insert_doc,  # type: ignore[arg-type]
+                session=self.session,
+                bulk_writer=self.bulk_writer,
+            )
+        except DuplicateKeyError:
+            # A concurrent caller inserted a matching document between our
+            # update and our insert. Re-run the update so the winning document
+            # receives the modifications instead of being duplicated.
+            retry_result = await self._update()
+            if (
+                retry_result is None
+                or getattr(retry_result, "matched_count", 1) == 0
+            ):
+                # Still nothing matched, so the duplicate key came from an
+                # unrelated unique index. Surface the original error.
+                raise
+            return retry_result
 
     @abstractmethod
     async def _update(self) -> UpdateResult: ...
@@ -191,13 +217,7 @@ class UpdateMany(UpdateQuery):
             return update_result
 
         if update_result is not None and update_result.matched_count == 0:
-            return (
-                yield from self.document_model.insert_one(
-                    document=self.upsert_insert_doc,
-                    session=self.session,
-                    bulk_writer=self.bulk_writer,
-                ).__await__()
-            )
+            return (yield from self._insert_on_upsert().__await__())
 
         return update_result
 
@@ -345,12 +365,6 @@ class UpdateOne(UpdateQuery):
             self.response_type is not UpdateResponse.UPDATE_RESULT
             and update_result is None
         ):
-            return (
-                yield from self.document_model.insert_one(
-                    document=self.upsert_insert_doc,
-                    session=self.session,
-                    bulk_writer=self.bulk_writer,
-                ).__await__()
-            )
+            return (yield from self._insert_on_upsert().__await__())
 
         return update_result

--- a/tests/odm/query/test_update.py
+++ b/tests/odm/query/test_update.py
@@ -4,7 +4,7 @@ import pytest
 
 from beanie.odm.operators.update.general import Max, Set
 from beanie.odm.queries.update import UpdateResponse
-from tests.odm.models import Sample
+from tests.odm.models import DocumentTestModelWithIndexFlags, Sample
 
 
 def test_update_query():
@@ -219,6 +219,45 @@ async def test_update_one_upsert_without_insert_return_doc(
         Sample.string == sample_doc_not_saved.string
     ).to_list()
     assert len(docs) == 0
+
+
+async def test_update_one_upsert_loses_insert_race():
+    query = DocumentTestModelWithIndexFlags.find_one(
+        DocumentTestModelWithIndexFlags.test_str == "concurrent"
+    ).upsert(
+        Set({DocumentTestModelWithIndexFlags.test_int: 5}),
+        on_insert=DocumentTestModelWithIndexFlags(
+            test_int=1, test_str="concurrent"
+        ),
+    )
+
+    # Simulate a concurrent caller inserting the same document between our
+    # update and our insert.
+    original_update = query._update
+    raced = []
+
+    async def racing_update():
+        result = await original_update()
+        if not raced:
+            raced.append(True)
+            await DocumentTestModelWithIndexFlags(
+                test_int=1, test_str="concurrent"
+            ).insert()
+        return result
+
+    query._update = racing_update
+    await query
+
+    assert (
+        await DocumentTestModelWithIndexFlags.find(
+            DocumentTestModelWithIndexFlags.test_str == "concurrent"
+        ).count()
+        == 1
+    )
+    doc = await DocumentTestModelWithIndexFlags.find_one(
+        DocumentTestModelWithIndexFlags.test_str == "concurrent"
+    )
+    assert doc.test_int == 5
 
 
 async def test_update_pymongo_kwargs(preset_documents):


### PR DESCRIPTION
Fixes #1350.

`upsert` runs as two separate steps: an update, then an insert when nothing
matched. Two concurrent callers can both see zero matches and both insert,
which creates duplicate documents.

This catches `DuplicateKeyError` from the insert and re-runs the update, so the
document inserted by the winning caller receives the modifications. If the
retried update still matches nothing, the duplicate key came from an unrelated
unique index and the original error is re-raised.

### Why not native `upsert=True`

Passing pymongo's `upsert=True` does not close the race on its own. MongoDB only
guarantees uniqueness when there is a unique index on the filtered fields
(SERVER-18784), so the same duplicates are still possible. It would also bypass
`Document.insert`, which would skip the `@before_event(Insert)` actions,
pre-insert validation, revision id initialization and link cascade that
`on_insert` documents currently get.

So a unique index over the filtered fields is required for concurrency safe
upserts. I am happy to add a note about that to the upsert docs if you want it.

### Test

The test replaces `_update` so that a competing document is inserted at the
exact point between the update and the insert. That makes it deterministic
rather than timing dependent. It fails on main with `DuplicateKeyError` and
passes with this change.
