### PR TITLE
fix: do not insert twice when upsert=True is passed to upsert (#1354)

### DIFF
--- a/beanie/odm/queries/update.py
+++ b/beanie/odm/queries/update.py
@@ -85,6 +85,14 @@ class UpdateQuery(UpdateMethods, SessionMethods, CloneInterface):
                 raise TypeError("Wrong expression type")
         return Encoder(custom_encoders=self.encoders).encode(query)
 
+    @property
+    def _native_upsert(self) -> bool:
+        """
+        True if the caller passed pymongo's own `upsert=True`, so the server
+        performs the insert and Beanie must not insert a second document.
+        """
+        return bool(self.pymongo_kwargs.get("upsert", False))
+
     @abstractmethod
     async def _update(self) -> UpdateResult: ...
 
@@ -187,7 +195,7 @@ class UpdateMany(UpdateQuery):
         """
 
         update_result = yield from self._update().__await__()
-        if self.upsert_insert_doc is None:
+        if self.upsert_insert_doc is None or self._native_upsert:
             return update_result
 
         if update_result is not None and update_result.matched_count == 0:
@@ -334,7 +342,7 @@ class UpdateOne(UpdateQuery):
         :return:
         """
         update_result = yield from self._update().__await__()
-        if self.upsert_insert_doc is None:
+        if self.upsert_insert_doc is None or self._native_upsert:
             return update_result
 
         if (

--- a/tests/odm/query/test_update.py
+++ b/tests/odm/query/test_update.py
@@ -221,6 +221,28 @@ async def test_update_one_upsert_without_insert_return_doc(
     assert len(docs) == 0
 
 
+async def test_update_one_upsert_with_native_upsert_kwarg(
+    preset_documents, sample_doc_not_saved
+):
+    await Sample.find_one(Sample.integer > 100000).upsert(
+        Set({Sample.integer: 100}),
+        on_insert=sample_doc_not_saved,
+        upsert=True,
+    )
+
+    # The server performed the upsert itself, so Beanie must not insert the
+    # on_insert document on top of it.
+    docs = await Sample.find_many(
+        Sample.string == sample_doc_not_saved.string
+    ).to_list()
+    assert len(docs) == 0
+
+    count = await Sample.get_pymongo_collection().count_documents(
+        {"integer": 100}
+    )
+    assert count == 1
+
+
 async def test_update_pymongo_kwargs(preset_documents):
     with pytest.raises(TypeError):
         await Sample.find_many(Sample.increment > 4).update(


### PR DESCRIPTION
Fixes #1354.

`pymongo_kwargs` is forwarded straight to pymongo, so passing `upsert=True`
together with `on_insert` made the server perform its own upsert and then Beanie
insert the `on_insert` document on top of it. That produced two documents on
every call, with no concurrency involved.

This skips Beanie's own insert when the caller has asked pymongo to perform the
upsert.

It also covers `response_type=UpdateResponse.OLD_DOCUMENT`, where
`find_one_and_update` with `upsert=True` and `ReturnDocument.BEFORE` returns
`None` after a server side upsert, which the previous code read as "nothing
matched".

Note that `on_insert` cannot be honoured when the server does the upsert, since
MongoDB builds the new document from the filter and the update operators rather
than from an arbitrary document. Raising on the combination instead of ignoring
`on_insert` would also be reasonable, but that would be a breaking change for
anyone currently passing both, so I went with the non-breaking option. Happy to
switch if you would rather it raised.

### Test

`test_update_one_upsert_with_native_upsert_kwarg` asserts that the `on_insert`
document is not inserted and that exactly one document is upserted by the
server. It fails on main and passes with this change.

This is independent of #1353 and can be merged in either order.
