### PR TITLE
fix: treat str method names as nested ExpressionField paths

### DIFF
--- a/beanie/odm/fields.py
+++ b/beanie/odm/fields.py
@@ -257,6 +257,19 @@ class ExpressionField(str):
 
         return FieldResolution()
 
+    def __getattribute__(self, item):
+        """Prefer nested field paths over inherited ``str`` methods.
+
+        ``ExpressionField`` is a ``str`` subclass, so names such as
+        ``title``, ``count``, ``index``, and ``format`` would otherwise
+        resolve to ``str`` methods and never reach ``__getattr__``.
+        That breaks queries like ``Chapter.subject.title == "..."``
+        (GitHub #1261). Private/dunder names still use normal lookup.
+        """
+        if isinstance(item, str) and item.startswith("_"):
+            return super().__getattribute__(item)
+        return ExpressionField.__getattr__(self, item)
+
     def __getitem__(self, item):
         """
         Get sub field

--- a/tests/odm/test_expression_fields.py
+++ b/tests/odm/test_expression_fields.py
@@ -1,6 +1,6 @@
 from beanie.odm.enums import SortDirection
 from beanie.odm.fields import ExpressionField, FieldResolution
-from beanie.odm.operators.find.comparison import In, NotIn
+from beanie.odm.operators.find.comparison import Eq, In, NotIn
 from beanie.odm.utils.relations import resolve_query_paths
 from tests.odm.models import (
     DocumentWithDeepNestedAlias,
@@ -282,3 +282,51 @@ class TestResolveQueryPaths:
         # $lookup stages come first, then $match with _id
         match_stages = [s for s in pipeline if "$match" in s]
         assert {"$match": {"door._id": "abc123"}} in match_stages
+
+
+def test_str_method_names_are_nested_fields():
+    """#1261: names that exist on str must still build nested field paths."""
+    field = ExpressionField("subject")
+    for name in (
+        "title",
+        "count",
+        "index",
+        "format",
+        "find",
+        "join",
+        "split",
+        "replace",
+        "strip",
+        "lower",
+        "upper",
+    ):
+        nested = getattr(field, name)
+        assert isinstance(nested, ExpressionField)
+        assert str(nested) == f"subject.{name}"
+
+
+def test_str_method_name_equality_builds_query():
+    """#1261: Chapter.subject.title == value must produce an Eq query."""
+    expr = ExpressionField("subject").title == "Mathematics"
+    assert isinstance(expr, Eq)
+    assert expr.query == {"subject.title": "Mathematics"}
+
+
+def test_str_method_name_resolves_model_field():
+    """#1261: alias resolution still runs for shadowed names on the model."""
+    from pydantic import BaseModel, Field
+
+    class Subject(BaseModel):
+        title: str
+        count: int = 0
+        item_count: int = Field(default=0, alias="itemCount")
+
+    field = ExpressionField(
+        "subject",
+        field_resolution=FieldResolution(model_class=Subject, is_link=True),
+    )
+    assert isinstance(field.title, ExpressionField)
+    assert str(field.title) == "subject.title"
+    assert field.title._field_resolution.is_link is True
+    assert str(field.count) == "subject.count"
+    assert str(field.item_count) == "subject.itemCount"


### PR DESCRIPTION
## Summary

`ExpressionField` subclasses `str`, so names that exist on `str` (`title`, `count`, `index`, `format`, …) were resolved as string methods and never reached `__getattr__`. Queries such as `Chapter.subject.title == "Mathematics"` therefore failed with `AttributeError` (or silently used the wrong object).

This routes public attribute access through the existing field-path constructor, while private/dunder names keep normal lookup.

Fixes #1261.

## Test plan

- [x] `pytest tests/odm/test_expression_fields.py -k str_method --no-cov` (3 new tests, no MongoDB required)
- [x] Confirmed `ExpressionField("subject").title` is now an `ExpressionField` with path `subject.title`
- [ ] Existing expression-field tests still pass (`tests/odm/test_expression_fields.py`, needs MongoDB)