### PR TITLE
docs: fix typo recieve -> receive

### DIFF
--- a/docs/tutorial/relations.md
+++ b/docs/tutorial/relations.md
@@ -297,7 +297,7 @@ class Person(Document):
 The `original_field` parameter is required for the back link field.
 In Pydantic v2, it must be passed using the json_schema_extra argument in Field(...) to avoid deprecation warnings and ensure compatibility.
 
-Back links support all the operations that normal links support, but are virtual. This means that when searching the database, you will need to include `fetch_links=True` (see [Finding documents](/tutorial/finding-documents).), or you will recieve an empty 'BackLink' virtual object. It is not possible to `fetch()` this virtual link after the initial search.
+Back links support all the operations that normal links support, but are virtual. This means that when searching the database, you will need to include `fetch_links=True` (see [Finding documents](/tutorial/finding-documents).), or you will receive an empty 'BackLink' virtual object. It is not possible to `fetch()` this virtual link after the initial search.
 
 ## Limitations
 


### PR DESCRIPTION
One-word typo fix in `docs/tutorial/relations.md:300`: "Back links support all the ope... recieve" → "receive".
