### PR TITLE
Allow Python 3.14

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -23,11 +23,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         # 5.0: kept for AWS DocumentDB / Azure DocumentDB compatibility
         # 7.0, 8.0: current supported MongoDB releases
         mongodb-version: [ "5.0", "7.0", "8.0" ]
         pydantic-version: [ "2.11", "2.12" ]
+        exclude:
+          # pydantic supports Python 3.14 starting with 2.12
+          - python-version: "3.14"
+            pydantic-version: "2.11"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "beanie"
 dynamic = ["version"]
 description = "Asynchronous Python ODM for MongoDB"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 license = { file="LICENSE" }
 authors = [
     {name = "Roman Right", email = "roman-right@protonmail.com"}
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "pydantic>=2.4,<3.0",


### PR DESCRIPTION
The library works with Python 3.14 as is, but it can't be installed with pip because it enforces the upper limit on the Python version.

Closes #1357 