### PR TITLE
Fix polymorphic timeseries collection initialization

### DIFF
--- a/beanie/odm/utils/init.py
+++ b/beanie/odm/utils/init.py
@@ -466,6 +466,7 @@ class Initializer:
                     document_settings.name
                 )
             )
+            self._existing_collections.append(document_settings.name)
         else:
             collection = self.database[document_settings.name]
 

--- a/tests/odm/models.py
+++ b/tests/odm/models.py
@@ -594,6 +594,23 @@ class DocumentWithTimeseries(Document):
         timeseries = TimeSeriesConfig(time_field="ts", expire_after_seconds=2)
 
 
+class MeasurementWithTimeseries(Document):
+    ts: datetime.datetime = Field(default_factory=datetime.datetime.now)
+
+    class Settings:
+        name = "measurements"
+        is_root = True
+        timeseries = TimeSeriesConfig(time_field="ts", granularity="seconds")
+
+
+class TemperatureMeasurement(MeasurementWithTimeseries):
+    temperature: float
+
+
+class HumidityMeasurement(MeasurementWithTimeseries):
+    humidity: float
+
+
 class DocumentWithStringField(Document):
     string_field: str
 

--- a/tests/odm/test_timesries_collection.py
+++ b/tests/odm/test_timesries_collection.py
@@ -89,3 +89,55 @@ async def test_timeseries_polymorphic_collection(db):
             },
             "info": {"readOnly": False},
         }
+
+
+async def test_timeseries_polymorphic_collection_created_once(db):
+    build_info = await db.command({"buildInfo": 1})
+    major_version = int(build_info["version"].split(".")[0])
+    if major_version < 5:
+        pytest.skip("Timeseries require MongoDB 5 or higher")
+
+    await db.drop_collection("measurements")
+
+    # `MeasurementWithTimeseries` and its two subclasses all share the
+    # "measurements" collection. Only the first one processed should call
+    # `create_collection`; the others must see it in the cache and reuse it,
+    # otherwise the second call raises CollectionInvalid.
+    original_create_collection = db.create_collection
+    created_names = []
+
+    async def counting_create_collection(name, *args, **kwargs):
+        created_names.append(name)
+        return await original_create_collection(name, *args, **kwargs)
+
+    db.create_collection = counting_create_collection
+    try:
+        await init_beanie(
+            database=db,
+            document_models=[
+                MeasurementWithTimeseries,
+                TemperatureMeasurement,
+                HumidityMeasurement,
+            ],
+        )
+    finally:
+        db.create_collection = original_create_collection
+
+    assert created_names == ["measurements"]
+
+    temperature = await TemperatureMeasurement(temperature=21.5).insert()
+    humidity = await HumidityMeasurement(humidity=55.0).insert()
+
+    found_by_id = {
+        doc.id: doc
+        for doc in await MeasurementWithTimeseries.find(
+            with_children=True
+        ).to_list()
+    }
+
+    found_temperature = found_by_id[temperature.id]
+    found_humidity = found_by_id[humidity.id]
+    assert isinstance(found_temperature, TemperatureMeasurement)
+    assert isinstance(found_humidity, HumidityMeasurement)
+    assert found_temperature.temperature == 21.5
+    assert found_humidity.humidity == 55.0

--- a/tests/odm/test_timesries_collection.py
+++ b/tests/odm/test_timesries_collection.py
@@ -2,7 +2,12 @@ import pytest
 
 from beanie import init_beanie
 from beanie.exceptions import MongoDBVersionError
-from tests.odm.models import DocumentWithTimeseries
+from tests.odm.models import (
+    DocumentWithTimeseries,
+    HumidityMeasurement,
+    MeasurementWithTimeseries,
+    TemperatureMeasurement,
+)
 
 
 async def test_timeseries_collection(db):
@@ -31,6 +36,51 @@ async def test_timeseries_collection(db):
             "type": "timeseries",
             "options": {
                 "expireAfterSeconds": 2,
+                "timeseries": {
+                    "timeField": "ts",
+                    "granularity": "seconds",
+                    "bucketMaxSpanSeconds": 3600,
+                },
+            },
+            "info": {"readOnly": False},
+        }
+
+
+async def test_timeseries_polymorphic_collection(db):
+    build_info = await db.command({"buildInfo": 1})
+    mongo_version = build_info["version"]
+    major_version = int(mongo_version.split(".")[0])
+    if major_version < 5:
+        with pytest.raises(MongoDBVersionError):
+            await init_beanie(
+                database=db,
+                document_models=[
+                    MeasurementWithTimeseries,
+                    TemperatureMeasurement,
+                    HumidityMeasurement,
+                ],
+            )
+
+    if major_version >= 5:
+        await db.drop_collection("measurements")
+        await init_beanie(
+            database=db,
+            document_models=[
+                MeasurementWithTimeseries,
+                TemperatureMeasurement,
+                HumidityMeasurement,
+            ],
+        )
+        info = await db.command(
+            {
+                "listCollections": 1,
+                "filter": {"name": "measurements"},
+            }
+        )
+        assert info["cursor"]["firstBatch"][0] == {
+            "name": "measurements",
+            "type": "timeseries",
+            "options": {
                 "timeseries": {
                     "timeField": "ts",
                     "granularity": "seconds",


### PR DESCRIPTION
## Summary

Fixes initialization of polymorphic time series documents that share the same collection.

`_existing_collections` is loaded once during initialization. When the first time series model creates a missing collection, the cached collection list was not updated, so subsequent subclasses sharing the same collection attempted to create it again and raised `CollectionInvalid`.

This change updates the cached collection list after a successful collection creation while preserving the startup optimization that avoids repeated `list_collection_names()` calls.

## Tests

Added a regression test covering multiple inherited document models sharing the same time series collection.

Fixes #1359