### PR TITLE
docs: fix context7.json description to reference PyMongo Async

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://context7.com/schema/context7.json",
     "projectTitle": "Beanie",
-    "description": "Asynchronous Python ODM for MongoDB, built on top of Motor and Pydantic, with a focus on type safety and developer experience.",
+    "description": "Asynchronous Python ODM for MongoDB, built on top of PyMongo Async and Pydantic, with a focus on type safety and developer experience.",
     "folders": [
         "docs"
     ],


### PR DESCRIPTION
Beanie switched from Motor to PyMongo Async in 2.0.0, but context7.json still described the project as built on Motor. Flagged in Discord by Marvel/Virtual1ty.