### PR TITLE
chore: add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ tilt_modules
 # Poetry stuff
 poetry.lock
 .pdm-python
+
+# Git worktrees
+.worktrees/

--- a/context7.json
+++ b/context7.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://context7.com/schema/context7.json",
     "projectTitle": "Beanie",
-    "description": "Asynchronous Python ODM for MongoDB, built on top of Motor and Pydantic, with a focus on type safety and developer experience.",
+    "description": "Asynchronous Python ODM for MongoDB, built on top of PyMongo Async and Pydantic, with a focus on type safety and developer experience.",
     "folders": [
         "docs"
     ],


### PR DESCRIPTION
Add .worktrees directory to gitignore to exclude git worktrees from version control.