### PR TITLE
chore: add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ tilt_modules
 # Poetry stuff
 poetry.lock
 .pdm-python
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
Add .worktrees directory to gitignore to exclude git worktrees from version control.