### PR TITLE
fix: resolve pre-existing pre-commit failures on main

### DIFF
--- a/beanie/odm/settings/view.py
+++ b/beanie/odm/settings/view.py
@@ -2,11 +2,12 @@ from typing import Any
 
 from pydantic import Field
 
+from beanie.odm.interfaces.getters import OtherGettersInterface
 from beanie.odm.settings.base import ItemSettings
 
 
 class ViewSettings(ItemSettings):
-    source: str | type
+    source: str | type[OtherGettersInterface]
     pipeline: list[dict[str, Any]]
 
     max_nesting_depths_per_field: dict = Field(default_factory=dict)

--- a/tests/fastapi/app.py
+++ b/tests/fastapi/app.py
@@ -29,9 +29,10 @@ async def live_span(_: FastAPI):
     async with AsyncMongoClient(Settings().mongodb_dsn) as client:
         await init_beanie(client.beanie_db, document_models=MODELS)
 
-        yield
-
-        await clean_db()
+        try:
+            yield
+        finally:
+            await clean_db()
 
 
 app = FastAPI(lifespan=live_span)

--- a/tests/odm/query/test_aggregate_methods.py
+++ b/tests/odm/query/test_aggregate_methods.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.odm.models import Sample
 
 
@@ -118,10 +120,10 @@ async def test_all_sum_without_docs(session):
 async def test_all_avg(preset_documents, session):
     n = await Sample.avg(Sample.increment)
 
-    assert n == 4.5
+    assert n == pytest.approx(4.5)
     n = await Sample.avg(Sample.increment, session=session)
 
-    assert n == 4.5
+    assert n == pytest.approx(4.5)
 
 
 async def test_all_avg_without_docs(session):


### PR DESCRIPTION
pre-commit.ci was failing on unrelated PRs because these issues already existed on main (likely surfaced by a ruff/mypy version bump). Fixes:

- tests/fastapi/app.py: wrap lifespan yield in try/finally so cleanup runs even if the app raises (ruff fallible-context-manager)
- tests/odm/query/test_aggregate_methods.py: use pytest.approx for float comparison instead of == (ruff float-equality-comparison)
- beanie/odm/settings/view.py: type ViewSettings.source as str | type[OtherGettersInterface] instead of bare type, so mypy can see get_collection_name() on the narrowed class (mypy attr-defined)